### PR TITLE
fix: Include README.md in Docker build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ ENV WEB_AUTH=true
 # Install uv for faster package management
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
-# Copy dependency files
-COPY pyproject.toml uv.lock ./
+# Copy dependency files and README (required by pyproject.toml)
+COPY pyproject.toml uv.lock README.md ./
 
 # Install dependencies only (not the app itself)
 RUN uv sync --frozen


### PR DESCRIPTION
The build was failing because pyproject.toml specifies readme = "README.md", but README.md wasn't being copied before running uv sync. This caused hatchling to fail during the package build with "OSError: Readme file does not exist: README.md".

Fixed by copying README.md along with pyproject.toml and uv.lock before running uv sync --frozen.