### PR TITLE
Fix: lowercase Docker image name & add local build option

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   gmail-cleaner:
-    image: ghcr.io/Gururagavendra/gmail-cleaner:latest
+    image: ghcr.io/gururagavendra/gmail-cleaner:latest
+    # Option 2: Build locally (uncomment below, comment out image above)
+    # build: .
     ports:
       - "8766:8766"  # Web UI
       - "8767:8767"  # OAuth callback


### PR DESCRIPTION
- Fixed image name to lowercase (Docker requirement)
- Added commented build option for local development

## Description

<!-- What does this PR do? -->

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Other

## Checklist

- [ ] I have tested my changes locally
- [ ] Docker build works (if modified)

## Related Issues

<!-- Fixes #123 -->
