### PR TITLE
fix: Add ARM64 platform compatibility for Docker Compose on macOS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   gmail-cleaner:
+    platform: linux/amd64
     image: ghcr.io/gururagavendra/gmail-cleaner:latest
     # Option 2: Build locally (uncomment below, comment out image above)
     # build: .


### PR DESCRIPTION
Description:
Add platform: linux/amd64 to the gmail-cleaner service in [docker-compose.yml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to enable running the pre-built Docker image on Apple Silicon (ARM64) Macs.

Problem:
Docker Compose was failing to start the service on ARM64 Macs with the error:

 ✘ gmail-cleaner Error no matching manifest for linux/arm64/v8 in the manifest list entries: no match for platform in manifest: not found

Solution:
Explicitly specify platform: linux/amd64 to allow Docker Desktop to emulate the AMD64 architecture on ARM64 Macs, eliminating the need for local builds.

Testing:
Run docker compose up -d on an ARM64 Mac and verify the service starts successfully.
