### PR TITLE
feat: Add multi-architecture Docker support (AMD64 + ARM64)

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -38,6 +38,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
 
+      # Set up QEMU for multi-platform builds
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       # set up Docker build action
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
@@ -68,6 +72,7 @@ jobs:
           file: "./Dockerfile"
           platforms: |
             linux/amd64
+            linux/arm64
           # Note: tags have to be all lower-case
           tags: ${{ steps.meta_main.outputs.tags }}
           labels: ${{ steps.meta_main.outputs.labels }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   gmail-cleaner:
-    platform: linux/amd64
+    # Multi-arch image: works natively on both AMD64 and ARM64 (Apple Silicon)
     image: ghcr.io/gururagavendra/gmail-cleaner:latest
     # Option 2: Build locally (uncomment below, comment out image above)
     # build: .


### PR DESCRIPTION
- Added QEMU setup step for cross-platform builds
- Build for both linux/amd64 and linux/arm64 platforms
- Removed platform constraint from docker-compose.yml
- Apple Silicon Macs now run natively instead of via Rosetta

