### PR TITLE
fix: all mark as read button logic

### DIFF
--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -56,7 +56,7 @@ class ScanRequest(BaseModel):
 
 class MarkReadRequest(BaseModel):
     """Request to mark emails as read."""
-    count: int = Field(default=100, ge=1, le=10000, description="Number of emails to mark")
+    count: int = Field(default=100, ge=1, le=100000, description="Number of emails to mark")
     filters: Optional[FiltersModel] = Field(default=None, description="Gmail filter options")
 
 
@@ -79,7 +79,7 @@ class DeleteEmailsRequest(BaseModel):
 
 class DeleteBulkRequest(BaseModel):
     """Request to delete emails from multiple senders."""
-    senders: list[str] = Field(default=[], max_items=50, description="List of sender addresses (max 50)")
+    senders: list[str] = Field(default=[], max_length=50, description="List of sender addresses (max 50)")
 
 
 # ----- Response Models -----

--- a/static/js/markread.js
+++ b/static/js/markread.js
@@ -30,7 +30,10 @@ GmailCleaner.MarkRead = {
         
         let count = countSelect.value;
         if (count === 'all') {
-            count = 999999;
+            // Get actual unread count from the displayed value
+            const countEl = document.querySelector('#unreadCount .count-number');
+            const unreadCount = parseInt(countEl.textContent.replace(/,/g, '')) || 10000;
+            count = unreadCount;
         } else {
             count = parseInt(count);
         }

--- a/tests/test_api_actions.py
+++ b/tests/test_api_actions.py
@@ -124,8 +124,8 @@ class TestMarkReadEndpoint:
         assert response.status_code == 200
 
     def test_mark_read_exceeds_max_count(self, client):
-        """POST /api/mark-read with count > 10000 should fail."""
-        response = client.post("/api/mark-read", json={"count": 10001})
+        """POST /api/mark-read with count > 100000 should fail."""
+        response = client.post("/api/mark-read", json={"count": 100001})
         assert response.status_code == 422
 
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -166,14 +166,14 @@ class TestMarkReadRequest:
         assert request.filters is None
 
     def test_count_maximum(self):
-        """Maximum count should be 10000."""
-        request = MarkReadRequest(count=10000)
-        assert request.count == 10000
+        """Maximum count should be 100000."""
+        request = MarkReadRequest(count=100000)
+        assert request.count == 100000
 
     def test_count_above_maximum(self):
-        """Count above 10000 should fail."""
+        """Count above 100000 should fail."""
         with pytest.raises(ValidationError):
-            MarkReadRequest(count=10001)
+            MarkReadRequest(count=100001)
 
 
 class TestDeleteBulkRequest:


### PR DESCRIPTION
## Description

"All unread emails" button logic is incorrect

## Checklist

- [x] I have tested my changes locally
- [ ] Docker build works (if modified)

## Related Issues

fixes: https://github.com/Gururagavendra/gmail-cleaner/issues/36
