### PR TITLE
fix: always show the consent screen and return a new refresh token

### DIFF
--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -137,6 +137,7 @@ def get_gmail_service():
                         bind_addr=bind_address,
                         host=settings.oauth_host,
                         open_browser=open_browser,
+                        prompt='consent' 
                     )
 
                     with open(settings.token_file, "w") as token:


### PR DESCRIPTION
## Description

Forces Google to always show the consent screen and return a new refresh token. This is important because:

- Google only issues a refresh token on the first authorization.
- If a user has previously authorized your app, subsequent authorizations won't include a refresh token by default
- Using prompt='consent' ensures you always get a fresh refresh token

## Checklist

- [ ] I have tested my changes locally
- [ ] Docker build works (if modified)

## Related Issues

<!-- Fixes #123 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Add prompt='consent' to InstalledAppFlow.run_local_server in run_oauth to force Google to always show the consent screen and return a fresh refresh token.
- Change implemented in app/services/auth.py (OAuth flow launched in background thread remains unchanged).
- No changes to public exports or control flow beyond the consent prompt behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->