### PR TITLE
feat: add env for redirect port

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -17,6 +17,10 @@ class Settings(BaseSettings):
     debug: bool = False
     port: int = 8766
     oauth_port: int = 8767
+    oauth_external_port: int | None = Field(
+        default=None,
+        description="External port for OAuth redirect URI (when different from oauth_port, e.g., Docker port mapping)",
+    )
 
     # Auth
     web_auth: bool = Field(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,12 @@
 services:
   gmail-cleaner:
     # Option 1: Multi-arch image: works natively on both AMD64 and ARM64 (Apple Silicon)
-    # image: ghcr.io/gururagavendra/gmail-cleaner:latest
+    image: ghcr.io/gururagavendra/gmail-cleaner:latest
+    pull_policy: always
 
     # Option 2: Build locally (uncomment below, comment out image above)
-    build: .
+    # build: .
+
     ports:
       - "8766:8766"  # Web UI
       - "8767:8767"  # OAuth callback
@@ -33,4 +35,8 @@ services:
 
       # Uncomment and set OAUTH_HOST if accessing via custom domain or server IP
       # - OAUTH_HOST=gmail.example.com
+
+      # Uncomment and set OAUTH_EXTERNAL_PORT if using custom port mapping
+      # (e.g., if you map ports like "18767:8767", set OAUTH_EXTERNAL_PORT=18767)
+      # - OAUTH_EXTERNAL_PORT=18767
     restart: unless-stopped


### PR DESCRIPTION
## Description

added env for external port

## Checklist

- [x] I have tested my changes locally
- [x] Docker build works (if modified)

## Related Issues

<!-- Fixes #123 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Configuration**: Added new optional `oauth_external_port` field to Settings to support custom external ports for OAuth redirect URIs (e.g., for Docker port mapping scenarios)
- **OAuth Redirect Handling**: Modified OAuth flow initialization to use `oauth_external_port` when configured, otherwise fallback to the default `oauth_port`, enabling proper redirect URI resolution with port mapping
- **Documentation**: Expanded README with new Advanced Configuration section covering custom port mapping and domain/reverse proxy setups, detailed troubleshooting for OAuth and authentication issues, and updated OAuth setup examples
- **Docker Setup**: Added commented guidance for `OAUTH_EXTERNAL_PORT` environment variable in docker-compose.yml, switched image pulling strategy to always use latest image, and made build option optional

<!-- end of auto-generated comment: release notes by coderabbit.ai -->