### PR TITLE
Move auth/session state to client and enable multi-user support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,17 +20,32 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        if: ${{ env.ACT != 'true' }}
         with:
           version: "latest"
 
       - name: Install dependencies
+        if: ${{ env.ACT != 'true' }}
         run: uv sync --group dev
 
       - name: Run tests
+        if: ${{ env.ACT != 'true' }}
         run: uv run pytest tests/ -v --cov=app --cov-report=xml
+
+      - name: Install dependencies (pip for act)
+        if: ${{ env.ACT == 'true' }}
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .
+          python -m pip install httpx pytest pytest-asyncio pytest-cov
+
+      - name: Run tests (pip for act)
+        if: ${{ env.ACT == 'true' }}
+        run: python -m pytest tests/ -v --cov=app --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
+        if: ${{ env.ACT != 'true' }}
         with:
           file: ./coverage.xml
           fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Python
 venv/
+.venv/
 __pycache__/
 *.pyc
 *.pyo

--- a/app/api/actions.py
+++ b/app/api/actions.py
@@ -65,10 +65,8 @@ def _get_request_host_and_scheme(request: Request) -> tuple[str, str]:
     host = forwarded_host or request.url.hostname or "localhost"
     if host and ":" in host and not host.startswith("["):
         host = host.split(":", 1)[0]
-    scheme = forwarded_proto or request.url.scheme or "http"
+    scheme = (forwarded_proto or request.url.scheme or "http").split(",")[0].strip()
     if scheme not in ("http", "https"):
-        scheme = "http"
-    if scheme == "https":
         scheme = "http"
     return host, scheme
 

--- a/app/api/actions.py
+++ b/app/api/actions.py
@@ -6,8 +6,9 @@ POST endpoints for triggering operations.
 
 import logging
 from functools import partial
-from fastapi import APIRouter, BackgroundTasks, HTTPException, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
 
+from app.api.deps import SessionContext, get_session_context
 from app.models import (
     ScanRequest,
     MarkReadRequest,
@@ -45,27 +46,52 @@ logger = logging.getLogger(__name__)
 
 
 @router.post("/scan")
-async def api_scan(request: ScanRequest, background_tasks: BackgroundTasks):
+async def api_scan(
+    request: ScanRequest,
+    background_tasks: BackgroundTasks,
+    ctx: SessionContext = Depends(get_session_context),
+):
     """Start email scan for unsubscribe links."""
     filters_dict = (
         request.filters.model_dump(exclude_none=True) if request.filters else None
     )
-    background_tasks.add_task(scan_emails, request.limit, filters_dict)
+    background_tasks.add_task(scan_emails, ctx.session, request.limit, filters_dict)
     return {"status": "started"}
 
 
+def _get_request_host_and_scheme(request: Request) -> tuple[str, str]:
+    forwarded_host = request.headers.get("x-forwarded-host")
+    forwarded_proto = request.headers.get("x-forwarded-proto")
+    host = forwarded_host or request.url.hostname or "localhost"
+    if host and ":" in host and not host.startswith("["):
+        host = host.split(":", 1)[0]
+    scheme = forwarded_proto or request.url.scheme or "http"
+    if scheme not in ("http", "https"):
+        scheme = "http"
+    if scheme == "https":
+        scheme = "http"
+    return host, scheme
+
+
 @router.post("/sign-in")
-async def api_sign_in(background_tasks: BackgroundTasks):
+async def api_sign_in(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    ctx: SessionContext = Depends(get_session_context),
+):
     """Trigger OAuth sign-in flow."""
-    background_tasks.add_task(get_gmail_service)
+    host, scheme = _get_request_host_and_scheme(request)
+    ctx.session.oauth_host = host
+    ctx.session.oauth_scheme = scheme
+    background_tasks.add_task(get_gmail_service, ctx.session, ctx.token_json, host, scheme)
     return {"status": "signing_in"}
 
 
 @router.post("/sign-out")
-async def api_sign_out():
+async def api_sign_out(ctx: SessionContext = Depends(get_session_context)):
     """Sign out and clear credentials."""
     try:
-        return sign_out()
+        return sign_out(ctx.session)
     except Exception as e:
         logger.exception("Error during sign-out")
         raise HTTPException(
@@ -88,29 +114,42 @@ async def api_unsubscribe(request: UnsubscribeRequest):
 
 
 @router.post("/mark-read")
-async def api_mark_read(request: MarkReadRequest, background_tasks: BackgroundTasks):
+async def api_mark_read(
+    request: MarkReadRequest,
+    background_tasks: BackgroundTasks,
+    ctx: SessionContext = Depends(get_session_context),
+):
     """Mark emails as read."""
     filters_dict = (
         request.filters.model_dump(exclude_none=True) if request.filters else None
     )
-    background_tasks.add_task(mark_emails_as_read, request.count, filters_dict)
+    background_tasks.add_task(
+        mark_emails_as_read, ctx.session, request.count, filters_dict
+    )
     return {"status": "started"}
 
 
 @router.post("/delete-scan")
 async def api_delete_scan(
-    request: DeleteScanRequest, background_tasks: BackgroundTasks
+    request: DeleteScanRequest,
+    background_tasks: BackgroundTasks,
+    ctx: SessionContext = Depends(get_session_context),
 ):
     """Scan senders for bulk delete."""
     filters_dict = (
         request.filters.model_dump(exclude_none=True) if request.filters else None
     )
-    background_tasks.add_task(scan_senders_for_delete, request.limit, filters_dict)
+    background_tasks.add_task(
+        scan_senders_for_delete, ctx.session, request.limit, filters_dict
+    )
     return {"status": "started"}
 
 
 @router.post("/delete-emails")
-async def api_delete_emails(request: DeleteEmailsRequest):
+async def api_delete_emails(
+    request: DeleteEmailsRequest,
+    ctx: SessionContext = Depends(get_session_context),
+):
     """Delete emails from a specific sender."""
     if not request.sender or not request.sender.strip():
         raise HTTPException(
@@ -118,7 +157,7 @@ async def api_delete_emails(request: DeleteEmailsRequest):
             detail="Sender email is required",
         )
     try:
-        return delete_emails_by_sender(request.sender)
+        return delete_emails_by_sender(ctx.session, request.sender)
     except Exception as e:
         logger.exception("Error deleting emails")
         raise HTTPException(
@@ -129,20 +168,26 @@ async def api_delete_emails(request: DeleteEmailsRequest):
 
 @router.post("/delete-emails-bulk")
 async def api_delete_emails_bulk(
-    request: DeleteBulkRequest, background_tasks: BackgroundTasks
+    request: DeleteBulkRequest,
+    background_tasks: BackgroundTasks,
+    ctx: SessionContext = Depends(get_session_context),
 ):
     """Delete emails from multiple senders (background task with progress)."""
-    background_tasks.add_task(delete_emails_bulk_background, request.senders)
+    background_tasks.add_task(
+        delete_emails_bulk_background, ctx.session, request.senders
+    )
     return {"status": "started"}
 
 
 @router.post("/download-emails")
 async def api_download_emails(
-    request: DownloadEmailsRequest, background_tasks: BackgroundTasks
+    request: DownloadEmailsRequest,
+    background_tasks: BackgroundTasks,
+    ctx: SessionContext = Depends(get_session_context),
 ):
     """Start downloading email metadata for selected senders."""
     # Note: Empty list is allowed - service function will handle it gracefully
-    background_tasks.add_task(download_emails_background, request.senders)
+    background_tasks.add_task(download_emails_background, ctx.session, request.senders)
     return {"status": "started"}
 
 
@@ -150,10 +195,13 @@ async def api_download_emails(
 
 
 @router.post("/labels")
-async def api_create_label(request: CreateLabelRequest):
+async def api_create_label(
+    request: CreateLabelRequest,
+    ctx: SessionContext = Depends(get_session_context),
+):
     """Create a new Gmail label."""
     try:
-        return create_label(request.name)
+        return create_label(ctx.session, request.name)
     except Exception as e:
         logger.exception("Error creating label")
         raise HTTPException(
@@ -163,7 +211,9 @@ async def api_create_label(request: CreateLabelRequest):
 
 
 @router.delete("/labels/{label_id}")
-async def api_delete_label(label_id: str):
+async def api_delete_label(
+    label_id: str, ctx: SessionContext = Depends(get_session_context)
+):
     """Delete a Gmail label."""
     if not label_id or not label_id.strip():
         raise HTTPException(
@@ -171,7 +221,7 @@ async def api_delete_label(label_id: str):
             detail="Label ID is required",
         )
     try:
-        return delete_label(label_id)
+        return delete_label(ctx.session, label_id)
     except Exception as e:
         logger.exception("Error deleting label")
         raise HTTPException(
@@ -182,7 +232,9 @@ async def api_delete_label(label_id: str):
 
 @router.post("/apply-label")
 async def api_apply_label(
-    request: ApplyLabelRequest, background_tasks: BackgroundTasks
+    request: ApplyLabelRequest,
+    background_tasks: BackgroundTasks,
+    ctx: SessionContext = Depends(get_session_context),
 ):
     """Apply a label to emails from selected senders."""
     if not request.label_id or not request.label_id.strip():
@@ -196,14 +248,19 @@ async def api_apply_label(
             detail="At least one sender is required",
         )
     background_tasks.add_task(
-        apply_label_to_senders_background, request.label_id, request.senders
+        apply_label_to_senders_background,
+        ctx.session,
+        request.label_id,
+        request.senders,
     )
     return {"status": "started"}
 
 
 @router.post("/remove-label")
 async def api_remove_label(
-    request: RemoveLabelRequest, background_tasks: BackgroundTasks
+    request: RemoveLabelRequest,
+    background_tasks: BackgroundTasks,
+    ctx: SessionContext = Depends(get_session_context),
 ):
     """Remove a label from emails from selected senders."""
     if not request.label_id or not request.label_id.strip():
@@ -217,26 +274,35 @@ async def api_remove_label(
             detail="At least one sender is required",
         )
     background_tasks.add_task(
-        remove_label_from_senders_background, request.label_id, request.senders
+        remove_label_from_senders_background,
+        ctx.session,
+        request.label_id,
+        request.senders,
     )
     return {"status": "started"}
 
 
 @router.post("/archive")
-async def api_archive(request: ArchiveRequest, background_tasks: BackgroundTasks):
+async def api_archive(
+    request: ArchiveRequest,
+    background_tasks: BackgroundTasks,
+    ctx: SessionContext = Depends(get_session_context),
+):
     """Archive emails from selected senders (remove from inbox)."""
     if not request.senders:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="At least one sender is required",
         )
-    background_tasks.add_task(archive_emails_background, request.senders)
+    background_tasks.add_task(archive_emails_background, ctx.session, request.senders)
     return {"status": "started"}
 
 
 @router.post("/mark-important")
 async def api_mark_important(
-    request: MarkImportantRequest, background_tasks: BackgroundTasks
+    request: MarkImportantRequest,
+    background_tasks: BackgroundTasks,
+    ctx: SessionContext = Depends(get_session_context),
 ):
     """Mark/unmark emails from selected senders as important."""
     if not request.senders:
@@ -245,6 +311,11 @@ async def api_mark_important(
             detail="At least one sender is required",
         )
     background_tasks.add_task(
-        partial(mark_important_background, request.senders, important=request.important)
+        partial(
+            mark_important_background,
+            ctx.session,
+            request.senders,
+            important=request.important,
+        )
     )
     return {"status": "started"}

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -1,0 +1,51 @@
+"""
+API Dependencies
+----------------
+Shared request context helpers for session-aware endpoints.
+"""
+
+import base64
+import binascii
+from dataclasses import dataclass
+
+from fastapi import Header, Request
+
+from app.core.state import SessionState, get_session_state
+
+
+@dataclass(slots=True)
+class SessionContext:
+    """Per-request session context."""
+
+    session_id: str
+    session: SessionState
+    token_json: str | None
+
+
+def _decode_auth_token(encoded: str | None) -> str | None:
+    """Decode base64 token JSON from header."""
+    if not encoded:
+        return None
+    try:
+        decoded = base64.b64decode(encoded.encode("utf-8"), validate=True)
+    except (ValueError, binascii.Error):
+        return None
+    try:
+        return decoded.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+
+
+def get_session_context(
+    request: Request,
+    x_session_id: str | None = Header(default=None),
+    x_auth_token: str | None = Header(default=None),
+) -> SessionContext:
+    """Build session context from headers/cookies."""
+    session_id = x_session_id or request.cookies.get("gc_session") or "default"
+    token_json = _decode_auth_token(x_auth_token)
+    session = get_session_state(session_id)
+    session.allow_token_file = not bool(x_session_id or request.cookies.get("gc_session"))
+    if token_json:
+        session.token_json = token_json
+    return SessionContext(session_id=session_id, session=session, token_json=token_json)

--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -1,4 +1,6 @@
 """Core module exports."""
 
 from .config import settings
-from .state import state
+from .state import get_session_state
+
+state = get_session_state("default")

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -6,12 +6,12 @@ Handles OAuth2 authentication with Gmail API.
 
 import json
 import logging
-import os
 import platform
 import shutil
 import threading
 import time
 from http.server import HTTPServer
+import os
 
 from google.auth.exceptions import RefreshError
 from google.auth.transport.requests import Request
@@ -19,15 +19,14 @@ from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 
-from app.core import settings, state
+from app.core import settings
+from app.core.state import SessionState, get_session_state
 from app.services.auth_handlers import OAuthCallbackHandler
 
 logger = logging.getLogger(__name__)
 
-
-# Track auth in progress
+# Backward-compatible auth progress flag (deprecated)
 _auth_in_progress = {"active": False}
-
 
 def _is_file_empty(file_path: str) -> bool:
     """Check if a file exists and is empty.
@@ -54,9 +53,30 @@ def is_web_auth_mode() -> bool:
     return settings.web_auth
 
 
-def needs_auth_setup() -> bool:
+def _load_credentials_from_token(token_json: str) -> Credentials | None:
+    """Load credentials from a token JSON string."""
+    try:
+        token_data = json.loads(token_json)
+    except (json.JSONDecodeError, TypeError) as e:
+        logger.warning(f"Invalid token JSON from client: {e}")
+        return None
+
+    try:
+        return Credentials.from_authorized_user_info(token_data, settings.scopes)
+    except Exception as e:
+        logger.warning(f"Failed to load credentials from client token: {e}")
+        return None
+
+
+def needs_auth_setup(
+    session: SessionState | None = None, token_json: str | None = None
+) -> bool:
     """Check if authentication is needed."""
-    if os.path.exists(settings.token_file):
+    session = session or get_session_state("default")
+    token_value = token_json or session.token_json
+    if not token_value and session.allow_token_file and os.path.exists(
+        settings.token_file
+    ):
         # Check if token file is empty
         if _is_file_empty(settings.token_file):
             logger.error(f"Token file {settings.token_file} is empty")
@@ -78,20 +98,32 @@ def needs_auth_setup() -> bool:
         except Exception as e:
             # Unexpected error - log it for debugging
             logger.error(f"Unexpected error checking auth setup: {e}", exc_info=True)
+
+    if not token_value:
+        return True
+
+    creds = _load_credentials_from_token(token_value)
+    if creds and (creds.valid or creds.refresh_token):
+        return False
     return True
 
 
-def get_web_auth_status() -> dict:
+def get_web_auth_status(
+    session: SessionState | None = None, token_json: str | None = None
+) -> dict:
     """Get current web auth status."""
+    session = session or get_session_state("default")
     return {
-        "needs_setup": needs_auth_setup(),
+        "needs_setup": needs_auth_setup(session, token_json),
         "web_auth_mode": is_web_auth_mode(),
         "has_credentials": os.path.exists(settings.credentials_file),
-        "pending_auth_url": state.pending_auth_url.get("url"),
+        "pending_auth_url": session.pending_auth_url.get("url"),
     }
 
 
-def _try_refresh_creds(creds: Credentials) -> Credentials | None:
+def _try_refresh_creds(
+    creds: Credentials, session: SessionState
+) -> Credentials | None:
     """Attempt to refresh expired credentials and save to token file.
 
     Args:
@@ -102,21 +134,25 @@ def _try_refresh_creds(creds: Credentials) -> Credentials | None:
     """
     try:
         creds.refresh(Request())
-        try:
-            with open(settings.token_file, "w") as token:
-                token.write(creds.to_json())
-        except OSError:
-            # Token file write failed - creds are refreshed in memory but not saved
-            logger.exception("Failed to save refreshed token")
+        session.token_json = creds.to_json()
+        session.pending_token_json = session.token_json
+        if session.allow_token_file:
+            try:
+                with open(settings.token_file, "w") as token:
+                    token.write(creds.to_json())
+            except OSError:
+                # Token file write failed - creds are refreshed in memory but not saved
+                logger.exception("Failed to save refreshed token")
         return creds
     except RefreshError as e:
         # Refresh token is invalid or expired
         logger.warning(f"Token refresh failed: {e}")
-        # Clear invalid token file
-        try:
-            os.remove(settings.token_file)
-        except OSError:
-            pass
+        session.token_json = None
+        if session.allow_token_file:
+            try:
+                os.remove(settings.token_file)
+            except OSError:
+                pass
         return None
 
 
@@ -182,15 +218,24 @@ def _get_credentials_path() -> str | None:
     return None
 
 
-def get_gmail_service():
+def get_gmail_service(
+    session: SessionState | None = None,
+    token_json: str | None = None,
+    oauth_host: str | None = None,
+    oauth_scheme: str | None = None,
+):
     """Get authenticated Gmail API service.
 
     Returns:
         tuple: (service, error_message) - service is None if auth needed
     """
+    session = session or get_session_state("default")
     creds = None
 
-    if os.path.exists(settings.token_file):
+    token_value = token_json or session.token_json
+    if token_value:
+        creds = _load_credentials_from_token(token_value)
+    elif session.allow_token_file and os.path.exists(settings.token_file):
         # Check if token file is empty
         if _is_file_empty(settings.token_file):
             logger.error(f"Token file {settings.token_file} is empty")
@@ -216,13 +261,13 @@ def get_gmail_service():
 
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:
-            creds = _try_refresh_creds(creds)
+            creds = _try_refresh_creds(creds, session)
 
         # If creds is still None or invalid after refresh attempt, trigger OAuth
         if not creds or not creds.valid:
             # Prevent multiple OAuth attempts (thread-safe check)
             # Note: Small race condition window, but acceptable for this use case
-            if _auth_in_progress.get("active", False):
+            if session.auth_in_progress:
                 return (
                     None,
                     "Sign-in already in progress. Please complete the authorization in your browser.",
@@ -244,6 +289,7 @@ def get_gmail_service():
                 )
 
             # Start OAuth in background thread so server stays responsive
+            session.auth_in_progress = True
             _auth_in_progress["active"] = True
 
             def run_oauth() -> None:
@@ -288,7 +334,17 @@ def get_gmail_service():
 
                     # For Docker: bind to 0.0.0.0 so callback can reach container
                     # For local: bind to localhost for security
-                    bind_address = "0.0.0.0" if is_web_auth_mode() else "localhost"  # nosec B104
+                    effective_host = (
+                        oauth_host or session.oauth_host or settings.oauth_host
+                    )
+                    effective_scheme = (
+                        oauth_scheme or session.oauth_scheme or "http"
+                    )
+                    bind_address = (
+                        "0.0.0.0"
+                        if is_web_auth_mode() or effective_host != "localhost"
+                        else "localhost"
+                    )  # nosec B104
 
                     # Handle custom external port (e.g., Docker port mapping like 18767:8767)
                     # The server listens on the internal port, but the redirect URI uses the external port
@@ -314,32 +370,23 @@ def get_gmail_service():
                             "Port must be between 1 and 65535."
                         )
 
-                    # Check if we should auto-open browser
-                    # In Docker/web mode: don't open browser, print URL to logs
-                    # On Windows/Mac/Linux desktop: auto-open browser
-                    if is_web_auth_mode():
-                        open_browser = False
-                    elif platform.system() == "Windows":
-                        open_browser = True
-                    elif platform.system() == "Darwin":  # macOS
-                        open_browser = True
-                    else:  # Linux
-                        open_browser = bool(
-                            shutil.which("xdg-open") or os.environ.get("DISPLAY")
-                        )
+                    # Always let the client open the authorization URL.
+                    open_browser = False
 
-                    # If external port is different, manually handle OAuth flow
-                    # because run_local_server() constructs redirect URI from port parameter
-                    if redirect_port != settings.oauth_port:
+                    manual_flow = True
+
+                    if manual_flow:
                         # Validate oauth_host is not empty
-                        if not settings.oauth_host or not settings.oauth_host.strip():
+                        if not effective_host or not effective_host.strip():
                             raise ValueError(
                                 "oauth_host cannot be empty when using custom external port. "
                                 "Please set OAUTH_HOST environment variable."
                             )
 
                         # Construct redirect URI using external port
-                        redirect_uri = f"http://{settings.oauth_host}:{redirect_port}/"
+                        redirect_uri = (
+                            f"{effective_scheme}://{effective_host}:{redirect_port}/"
+                        )
                         flow.redirect_uri = redirect_uri
                         logger.info(
                             f"Using custom redirect URI {redirect_uri} "
@@ -361,17 +408,16 @@ def get_gmail_service():
                             )
 
                         # Store OAuth state for CSRF protection
-                        with state.oauth_state_lock:
-                            state.oauth_state["state"] = oauth_state
+                        with session.oauth_state_lock:
+                            session.oauth_state["state"] = oauth_state
                         logger.debug(
                             f"Stored OAuth state for CSRF protection: {oauth_state[:20]}..."
                             if oauth_state and len(oauth_state) > 20
                             else f"Stored OAuth state: {oauth_state}"
                         )
 
-                        # Set pending auth URL for web auth mode
-                        if is_web_auth_mode():
-                            state.pending_auth_url["url"] = authorization_url
+                        # Store pending auth URL so client can open it
+                        session.pending_auth_url["url"] = authorization_url
 
                         # Create a simple HTTP server to handle the callback
                         callback_event = threading.Event()
@@ -386,6 +432,7 @@ def get_gmail_service():
                                 callback_event,
                                 callback_lock,
                                 callback_data,
+                                session,
                                 *args,
                                 **kwargs,
                             )
@@ -418,14 +465,6 @@ def get_gmail_service():
                                 f"Please visit this URL to authorize the application: {authorization_url}"
                             )
                             logger.info(f"OAuth authorization URL: {authorization_url}")
-
-                            if open_browser:
-                                try:
-                                    import webbrowser
-
-                                    webbrowser.open(authorization_url)
-                                except Exception as e:
-                                    logger.warning(f"Failed to open browser: {e}")
 
                             # Wait for the callback (with timeout)
                             timeout = 300  # 5 minutes
@@ -503,7 +542,7 @@ def get_gmail_service():
                         new_creds = flow.run_local_server(
                             port=settings.oauth_port,
                             bind_addr=bind_address,
-                            host=settings.oauth_host,
+                            host=effective_host,
                             open_browser=open_browser,
                             prompt="consent",
                         )
@@ -515,14 +554,21 @@ def get_gmail_service():
                         )
 
                     # Save token with error handling
-                    try:
-                        with open(settings.token_file, "w") as token:
-                            token.write(new_creds.to_json())
-                        print("OAuth complete! Token saved.")
-                    except OSError as e:
-                        logger.error(f"Failed to save token file: {e}", exc_info=True)
-                        print(f"OAuth completed but failed to save token: {e}")
-                        raise  # Re-raise so outer exception handler can log it
+                    session.token_json = new_creds.to_json()
+                    session.pending_token_json = session.token_json
+                    if session.allow_token_file:
+                        try:
+                            with open(settings.token_file, "w") as token:
+                                token.write(new_creds.to_json())
+                            print("OAuth complete! Token saved.")
+                        except OSError as e:
+                            logger.error(
+                                f"Failed to save token file: {e}", exc_info=True
+                            )
+                            print(f"OAuth completed but failed to save token: {e}")
+                            raise  # Re-raise so outer exception handler can log it
+                    else:
+                        print("OAuth complete! Token ready.")
                 except (ValueError, json.JSONDecodeError) as e:
                     # JSON parsing errors from OAuth callback (shouldn't happen if credentials were valid)
                     error_msg = str(e)
@@ -582,10 +628,11 @@ def get_gmail_service():
                         print(f"OAuth error: {e}")
                 finally:
                     # Always reset auth state, even on error
+                    session.auth_in_progress = False
                     _auth_in_progress["active"] = False
-                    state.pending_auth_url["url"] = None
-                    with state.oauth_state_lock:
-                        state.oauth_state["state"] = None
+                    session.pending_auth_url["url"] = None
+                    with session.oauth_state_lock:
+                        session.oauth_state["state"] = None
 
             oauth_thread = threading.Thread(target=run_oauth, daemon=True)
             oauth_thread.start()
@@ -608,25 +655,31 @@ def get_gmail_service():
 
     try:
         profile = service.users().getProfile(userId="me").execute()
-        state.current_user["email"] = profile.get("emailAddress", "Unknown")
-        state.current_user["logged_in"] = True
+        session.current_user["email"] = profile.get("emailAddress", "Unknown")
+        session.current_user["logged_in"] = True
     except Exception:
-        state.current_user["email"] = "Unknown"
-        state.current_user["logged_in"] = True
+        session.current_user["email"] = "Unknown"
+        session.current_user["logged_in"] = True
 
     return service, None
 
 
-def sign_out() -> dict:
-    """Sign out by removing the token file."""
-    if os.path.exists(settings.token_file):
+def sign_out(session: SessionState | None = None) -> dict:
+    """Sign out by clearing session credentials and state."""
+    session = session or get_session_state("default")
+    session.token_json = None
+    session.pending_token_json = None
+    session.current_user = {"email": None, "logged_in": False}
+    session.reset_scan()
+    session.reset_delete_scan()
+    session.reset_mark_read()
+    session.reset_delete_bulk()
+    session.reset_download()
+    session.reset_label_operation()
+    session.reset_archive()
+    session.reset_important()
+    if session.allow_token_file and os.path.exists(settings.token_file):
         os.remove(settings.token_file)
-
-    # Reset state
-    state.current_user = {"email": None, "logged_in": False}
-    state.reset_scan()
-    state.reset_delete_scan()
-    state.reset_mark_read()
 
     print("Signed out - results cleared")
     return {
@@ -636,9 +689,36 @@ def sign_out() -> dict:
     }
 
 
-def check_login_status() -> dict:
+def check_login_status(
+    session: SessionState | None = None, token_json: str | None = None
+) -> dict:
     """Check if user is logged in and get their email."""
-    if os.path.exists(settings.token_file):
+    session = session or get_session_state("default")
+    token_value = token_json or session.pending_token_json or session.token_json
+    if token_value:
+        creds = _load_credentials_from_token(token_value)
+        try:
+            if creds and creds.valid:
+                service = build("gmail", "v1", credentials=creds)
+                profile = service.users().getProfile(userId="me").execute()
+                session.current_user["email"] = profile.get("emailAddress", "Unknown")
+                session.current_user["logged_in"] = True
+                session.token_json = token_value
+                return session.current_user.copy()
+            if creds and creds.expired and creds.refresh_token:
+                refreshed_creds = _try_refresh_creds(creds, session)
+                if refreshed_creds:
+                    service = build("gmail", "v1", credentials=refreshed_creds)
+                    profile = service.users().getProfile(userId="me").execute()
+                    session.current_user["email"] = profile.get(
+                        "emailAddress", "Unknown"
+                    )
+                    session.current_user["logged_in"] = True
+                    return session.current_user.copy()
+        except Exception as e:
+            # API errors, network issues, etc.
+            logger.error(f"Error checking login status: {e}", exc_info=True)
+    elif session.allow_token_file and os.path.exists(settings.token_file):
         # Check if token file is empty
         if _is_file_empty(settings.token_file):
             logger.error(f"Token file {settings.token_file} is empty")
@@ -654,19 +734,19 @@ def check_login_status() -> dict:
                 if creds and creds.valid:
                     service = build("gmail", "v1", credentials=creds)
                     profile = service.users().getProfile(userId="me").execute()
-                    state.current_user["email"] = profile.get("emailAddress", "Unknown")
-                    state.current_user["logged_in"] = True
-                    return state.current_user.copy()
+                    session.current_user["email"] = profile.get("emailAddress", "Unknown")
+                    session.current_user["logged_in"] = True
+                    return session.current_user.copy()
                 elif creds and creds.expired and creds.refresh_token:
-                    refreshed_creds = _try_refresh_creds(creds)
+                    refreshed_creds = _try_refresh_creds(creds, session)
                     if refreshed_creds:
                         service = build("gmail", "v1", credentials=refreshed_creds)
                         profile = service.users().getProfile(userId="me").execute()
-                        state.current_user["email"] = profile.get(
+                        session.current_user["email"] = profile.get(
                             "emailAddress", "Unknown"
                         )
-                        state.current_user["logged_in"] = True
-                        return state.current_user.copy()
+                        session.current_user["logged_in"] = True
+                        return session.current_user.copy()
             except (ValueError, OSError) as e:
                 # Token file is invalid/corrupted
                 logger.warning(f"Failed to load or refresh credentials: {e}")
@@ -679,6 +759,6 @@ def check_login_status() -> dict:
                 # API errors, network issues, etc.
                 logger.error(f"Error checking login status: {e}", exc_info=True)
 
-    state.current_user["email"] = None
-    state.current_user["logged_in"] = False
-    return state.current_user.copy()
+    session.current_user["email"] = None
+    session.current_user["logged_in"] = False
+    return session.current_user.copy()

--- a/static/css/responsive.css
+++ b/static/css/responsive.css
@@ -23,23 +23,111 @@
 
 /* Mobile */
 @media (max-width: 768px) {
+    html, body {
+        width: 100%;
+        overflow-x: hidden;
+    }
+
+    .app-container,
+    .main-wrapper,
+    .main-content,
+    .header,
+    .filter-bar,
+    .main-content-inner {
+        max-width: 100%;
+        overflow-x: hidden;
+    }
+
     .header {
-        padding: 12px 16px;
+        padding: 10px 12px;
+        height: auto;
+        gap: 8px;
+        z-index: 200;
+    }
+
+    .header-left {
+        gap: 6px;
+        min-width: 0;
+        flex: 1 1 auto;
+    }
+
+    .header-right {
+        min-width: 0;
+        flex: 0 1 auto;
+    }
+
+    .menu-btn {
+        width: 40px;
+        height: 40px;
     }
 
     .header h1 {
         font-size: 18px;
     }
 
-    .sidebar {
-        position: fixed;
-        left: -250px;
-        z-index: 1000;
-        width: 250px;
-        transition: left 0.3s ease;
+    .logo {
+        min-width: 0;
     }
 
-    .sidebar.active {
+    .logo-text {
+        font-size: 18px;
+    }
+
+    .user-section {
+        gap: 8px;
+        min-width: 0;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+    }
+
+    .user-email {
+        display: none;
+    }
+
+    .user-avatar {
+        user-select: none;
+        -webkit-user-select: none;
+        -ms-user-select: none;
+        -webkit-touch-callout: none;
+        outline: none;
+        box-shadow: none;
+        -webkit-tap-highlight-color: transparent;
+        touch-action: manipulation;
+    }
+
+    .user-avatar:focus,
+    .user-avatar:active {
+        outline: none;
+        box-shadow: none;
+    }
+
+    .user-avatar * {
+        user-select: none;
+        -webkit-user-select: none;
+        -ms-user-select: none;
+    }
+
+    .header .btn-sm {
+        padding: 6px 10px;
+        font-size: 12px;
+    }
+
+    .sidebar {
+        position: fixed;
+        left: -280px;
+        z-index: 180;
+        width: 280px;
+        height: 100vh;
+        top: 0;
+        padding-top: 64px;
+        border-right: 1px solid var(--border-color);
+        box-shadow: var(--shadow-md);
+        transition: left 0.25s ease;
+        overflow-y: auto;
+    }
+
+    .sidebar.active,
+    .sidebar.open {
         left: 0;
     }
 
@@ -58,20 +146,32 @@
         padding: 16px;
     }
 
+    .main-content-inner {
+        padding: 16px;
+        max-width: 100%;
+    }
+
     /* Mobile menu overlay */
     .sidebar-overlay {
         display: none;
         position: fixed;
-        top: 60px;
+        top: 0;
         left: 0;
         right: 0;
         bottom: 0;
-        background: rgba(0, 0, 0, 0.3);
-        z-index: 999;
+        background: rgba(32, 33, 36, 0.35);
+        backdrop-filter: blur(2px);
+        z-index: 170;
+        pointer-events: none;
     }
 
     .sidebar-overlay.active {
         display: block;
+        pointer-events: auto;
+    }
+
+    body.sidebar-open {
+        overflow: hidden;
     }
 
     /* Show menu button on mobile */
@@ -82,15 +182,36 @@
     /* Filter bar mobile */
     .filter-bar {
         flex-wrap: wrap;
-        padding: 12px;
+        padding: 12px 16px;
+    }
+
+    .filter-bar-content {
+        gap: 12px;
     }
 
     .filter-group {
         width: 100%;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 6px;
     }
 
     .filter-select {
         width: 100%;
+        min-width: 0;
+    }
+
+    .filter-input,
+    .date-range-input {
+        width: 100%;
+        min-width: 0;
+    }
+
+    .filter-clear-btn {
+        width: 100%;
+        justify-content: center;
+        margin-left: 0;
+        padding: 10px 12px;
     }
 
     .filter-actions {
@@ -103,23 +224,53 @@
         padding: 16px;
     }
 
+    .scan-row {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 12px;
+    }
+
+    .scan-row .btn {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .form-select {
+        max-width: none;
+    }
+
     /* Results */
+    .results-list {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    .result-item {
+        flex-wrap: nowrap;
+        min-width: 720px;
+    }
+
     .result-content {
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
     }
 
     .result-sender {
-        width: 100%;
+        width: 200px;
     }
 
     .result-subject {
-        width: 100%;
+        width: 300px;
+    }
+
+    .result-meta {
+        min-width: 180px;
     }
 
     .result-actions {
-        width: 100%;
+        width: auto;
         margin-left: 0;
-        margin-top: 8px;
+        margin-top: 0;
+        flex-wrap: wrap;
     }
 
     /* Toolbar */
@@ -130,6 +281,30 @@
 
     .toolbar-left, .toolbar-right {
         flex-wrap: wrap;
+        width: 100%;
+    }
+
+    .toolbar-right .btn {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .action-row {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .action-group {
+        flex-wrap: wrap;
+    }
+
+    .action-divider {
+        display: none;
+    }
+
+    .btn.btn-action {
+        width: 100%;
+        justify-content: center;
     }
 
     /* Unread info */
@@ -192,6 +367,88 @@
         width: 24px;
         height: 24px;
         font-size: 12px;
+    }
+}
+
+/* Touch devices with wide CSS viewports */
+@media (pointer: coarse) and (min-width: 769px) {
+    .sidebar {
+        position: fixed;
+        left: -250px;
+        z-index: 1000;
+        width: 250px;
+        transition: left 0.3s ease;
+    }
+
+    .sidebar.active,
+    .sidebar.open {
+        left: 0;
+    }
+
+    .main-content {
+        margin-left: 0;
+        padding: 16px;
+    }
+
+    .main-content-inner {
+        padding: 16px;
+        max-width: 100%;
+    }
+
+    .filter-bar {
+        padding: 12px 16px;
+    }
+
+    .filter-bar-content {
+        gap: 12px;
+    }
+
+    .filter-group {
+        width: 100%;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 6px;
+    }
+
+    .filter-select,
+    .filter-input,
+    .date-range-input {
+        width: 100%;
+        min-width: 0;
+    }
+
+    .filter-clear-btn {
+        width: 100%;
+        justify-content: center;
+        margin-left: 0;
+        padding: 10px 12px;
+    }
+
+    .scan-row {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 12px;
+    }
+
+    .scan-row .btn {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .toolbar {
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+
+    .toolbar-left,
+    .toolbar-right {
+        flex-wrap: wrap;
+        width: 100%;
+    }
+
+    .toolbar-right .btn {
+        width: 100%;
+        justify-content: center;
     }
 }
 

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -1,0 +1,66 @@
+/**
+ * Gmail Cleaner - API helpers
+ */
+
+window.GmailCleaner = window.GmailCleaner || {};
+
+GmailCleaner.Session = {
+    sessionKey: 'gc_session_id',
+    tokenKey: 'gc_token_json',
+
+    getSessionId() {
+        let sessionId = localStorage.getItem(this.sessionKey);
+        if (!sessionId) {
+            if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+                sessionId = window.crypto.randomUUID();
+            } else {
+                sessionId = `sess_${Math.random().toString(36).slice(2)}${Date.now()}`;
+            }
+            localStorage.setItem(this.sessionKey, sessionId);
+        }
+        return sessionId;
+    },
+
+    getToken() {
+        return localStorage.getItem(this.tokenKey);
+    },
+
+    setToken(tokenJson) {
+        if (tokenJson) {
+            localStorage.setItem(this.tokenKey, tokenJson);
+        }
+    },
+
+    clearToken() {
+        localStorage.removeItem(this.tokenKey);
+    },
+
+    encodeToken(tokenJson) {
+        if (!tokenJson) return null;
+        try {
+            return btoa(unescape(encodeURIComponent(tokenJson)));
+        } catch (error) {
+            console.warn('Failed to encode auth token:', error);
+            return null;
+        }
+    }
+};
+
+GmailCleaner.apiFetch = async function apiFetch(url, options = {}) {
+    const sessionId = GmailCleaner.Session.getSessionId();
+    const tokenJson = GmailCleaner.Session.getToken();
+    const authToken = GmailCleaner.Session.encodeToken(tokenJson);
+
+    const headers = new Headers(options.headers || {});
+    headers.set('X-Session-Id', sessionId);
+    if (authToken) {
+        headers.set('X-Auth-Token', authToken);
+    }
+
+    const requestOptions = {
+        ...options,
+        headers
+    };
+
+    return fetch(url, requestOptions);
+};

--- a/static/js/delete.js
+++ b/static/js/delete.js
@@ -44,8 +44,11 @@ GmailCleaner.Delete = {
     async startScan() {
         if (GmailCleaner.deleteScanning) return;
 
-        const authResponse = await fetch('/api/auth-status');
+        const authResponse = await GmailCleaner.apiFetch('/api/auth-status');
         const authStatus = await authResponse.json();
+        if (authStatus.token_json) {
+            GmailCleaner.Session.setToken(authStatus.token_json);
+        }
 
         if (!authStatus.logged_in) {
             GmailCleaner.Auth.signIn();
@@ -70,7 +73,7 @@ GmailCleaner.Delete = {
         const filters = GmailCleaner.Filters.get();
 
         try {
-            const response = await fetch('/api/delete-scan', {
+            const response = await GmailCleaner.apiFetch('/api/delete-scan', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
@@ -94,7 +97,7 @@ GmailCleaner.Delete = {
 
     async pollProgress() {
         try {
-            const response = await fetch('/api/delete-scan-status');
+            const response = await GmailCleaner.apiFetch('/api/delete-scan-status');
             const status = await response.json();
 
             const progressBar = document.getElementById('deleteProgressBar');
@@ -105,7 +108,7 @@ GmailCleaner.Delete = {
 
             if (status.done) {
                 if (!status.error) {
-                    const resultsResponse = await fetch('/api/delete-scan-results');
+                    const resultsResponse = await GmailCleaner.apiFetch('/api/delete-scan-results');
                     GmailCleaner.deleteResults = await resultsResponse.json();
                     this.displayResults();
                 } else {
@@ -223,7 +226,7 @@ GmailCleaner.Delete = {
         `;
 
         try {
-            const response = await fetch('/api/delete-emails', {
+            const response = await GmailCleaner.apiFetch('/api/delete-emails', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ sender: r.email })
@@ -293,7 +296,7 @@ GmailCleaner.Delete = {
 
         try {
             // Start the background task
-            await fetch('/api/delete-emails-bulk', {
+            await GmailCleaner.apiFetch('/api/delete-emails-bulk', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ senders: senderEmails })
@@ -309,7 +312,7 @@ GmailCleaner.Delete = {
 
     async pollDeleteProgress(checkboxes) {
         try {
-            const response = await fetch('/api/delete-bulk-status');
+            const response = await GmailCleaner.apiFetch('/api/delete-bulk-status');
             const status = await response.json();
 
             // Update progress bar in overlay
@@ -330,7 +333,7 @@ GmailCleaner.Delete = {
                     });
 
                     setTimeout(async () => {
-                        const resultsResponse = await fetch('/api/delete-scan-results');
+                        const resultsResponse = await GmailCleaner.apiFetch('/api/delete-scan-results');
                         GmailCleaner.deleteResults = await resultsResponse.json();
                         this.displayResults();
                         document.getElementById('deleteSelectAll').checked = false;
@@ -433,7 +436,7 @@ GmailCleaner.Delete = {
 
         try {
             // Start background download
-            await fetch('/api/download-emails', {
+            await GmailCleaner.apiFetch('/api/download-emails', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ senders: senderEmails })
@@ -449,7 +452,7 @@ GmailCleaner.Delete = {
 
     async pollDownloadProgress() {
         try {
-            const response = await fetch('/api/download-status');
+            const response = await GmailCleaner.apiFetch('/api/download-status');
             const status = await response.json();
 
             this.updateDownloadOverlay(status);

--- a/static/js/labels.js
+++ b/static/js/labels.js
@@ -12,7 +12,7 @@ GmailCleaner.Labels = {
 
     async loadLabels() {
         try {
-            const response = await fetch('/api/labels');
+            const response = await GmailCleaner.apiFetch('/api/labels');
             const data = await response.json();
 
             if (data.success) {
@@ -31,7 +31,7 @@ GmailCleaner.Labels = {
 
     async createLabel(name) {
         try {
-            const response = await fetch('/api/labels', {
+            const response = await GmailCleaner.apiFetch('/api/labels', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ name })
@@ -52,7 +52,7 @@ GmailCleaner.Labels = {
 
     async deleteLabel(labelId) {
         try {
-            const response = await fetch(`/api/labels/${encodeURIComponent(labelId)}`, {
+            const response = await GmailCleaner.apiFetch(`/api/labels/${encodeURIComponent(labelId)}`, {
                 method: 'DELETE'
             });
             const result = await response.json();
@@ -70,7 +70,7 @@ GmailCleaner.Labels = {
 
     async applyLabelToSenders(labelId, senders) {
         try {
-            const response = await fetch('/api/apply-label', {
+            const response = await GmailCleaner.apiFetch('/api/apply-label', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ label_id: labelId, senders })
@@ -83,7 +83,7 @@ GmailCleaner.Labels = {
 
     async removeLabelFromSenders(labelId, senders) {
         try {
-            const response = await fetch('/api/remove-label', {
+            const response = await GmailCleaner.apiFetch('/api/remove-label', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ label_id: labelId, senders })
@@ -96,7 +96,7 @@ GmailCleaner.Labels = {
 
     async pollLabelOperation(onComplete) {
         try {
-            const response = await fetch('/api/label-operation-status');
+            const response = await GmailCleaner.apiFetch('/api/label-operation-status');
             const status = await response.json();
 
             if (status.done) {
@@ -401,7 +401,7 @@ GmailCleaner.Labels = {
         this.showArchiveOverlay(senders.length);
 
         try {
-            const response = await fetch('/api/archive', {
+            const response = await GmailCleaner.apiFetch('/api/archive', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ senders })
@@ -423,7 +423,7 @@ GmailCleaner.Labels = {
 
     async pollArchiveStatus() {
         try {
-            const response = await fetch('/api/archive-status');
+            const response = await GmailCleaner.apiFetch('/api/archive-status');
             const status = await response.json();
 
             this.updateArchiveOverlay(status);
@@ -508,7 +508,7 @@ GmailCleaner.Labels = {
         this.showImportantOverlay(senders.length);
 
         try {
-            const response = await fetch('/api/mark-important', {
+            const response = await GmailCleaner.apiFetch('/api/mark-important', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ senders, important: true })
@@ -530,7 +530,7 @@ GmailCleaner.Labels = {
 
     async pollImportantStatus() {
         try {
-            const response = await fetch('/api/important-status');
+            const response = await GmailCleaner.apiFetch('/api/important-status');
             const status = await response.json();
 
             this.updateImportantOverlay(status);
@@ -598,8 +598,11 @@ GmailCleaner.Labels = {
 document.addEventListener('DOMContentLoaded', async () => {
     // Load labels after a short delay to ensure auth check completes
     setTimeout(async () => {
-        const authResponse = await fetch('/api/auth-status');
+        const authResponse = await GmailCleaner.apiFetch('/api/auth-status');
         const authStatus = await authResponse.json();
+        if (authStatus.token_json) {
+            GmailCleaner.Session.setToken(authStatus.token_json);
+        }
         if (authStatus.logged_in) {
             await GmailCleaner.Labels.loadLabels();
         }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -4,13 +4,14 @@
  */
 
 // Global state
-window.GmailCleaner = {
+window.GmailCleaner = window.GmailCleaner || {};
+Object.assign(window.GmailCleaner, {
     results: [],
     deleteResults: [],
     scanning: false,
     deleteScanning: false,
     currentView: 'login'
-};
+});
 
 // Initialize on page load
 document.addEventListener('DOMContentLoaded', () => {

--- a/static/js/markread.js
+++ b/static/js/markread.js
@@ -10,7 +10,7 @@ GmailCleaner.MarkRead = {
         countEl.textContent = '...';
 
         try {
-            const response = await fetch('/api/unread-count');
+            const response = await GmailCleaner.apiFetch('/api/unread-count');
             const data = await response.json();
 
             if (data.error) {
@@ -47,7 +47,7 @@ GmailCleaner.MarkRead = {
         progressCard.classList.remove('hidden');
 
         try {
-            await fetch('/api/mark-read', {
+            await GmailCleaner.apiFetch('/api/mark-read', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
@@ -64,7 +64,7 @@ GmailCleaner.MarkRead = {
 
     async pollProgress() {
         try {
-            const response = await fetch('/api/mark-read-status');
+            const response = await GmailCleaner.apiFetch('/api/mark-read-status');
             const status = await response.json();
 
             const progressBar = document.getElementById('markReadProgressBar');

--- a/static/js/scanner.js
+++ b/static/js/scanner.js
@@ -44,8 +44,11 @@ GmailCleaner.Scanner = {
     async startScan() {
         if (GmailCleaner.scanning) return;
 
-        const authResponse = await fetch('/api/auth-status');
+        const authResponse = await GmailCleaner.apiFetch('/api/auth-status');
         const authStatus = await authResponse.json();
+        if (authStatus.token_json) {
+            GmailCleaner.Session.setToken(authStatus.token_json);
+        }
 
         if (!authStatus.logged_in) {
             GmailCleaner.Auth.signIn();
@@ -71,7 +74,7 @@ GmailCleaner.Scanner = {
         const filters = GmailCleaner.Filters.get();
 
         try {
-            await fetch('/api/scan', {
+            await GmailCleaner.apiFetch('/api/scan', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
@@ -88,7 +91,7 @@ GmailCleaner.Scanner = {
 
     async pollProgress() {
         try {
-            const response = await fetch('/api/status');
+            const response = await GmailCleaner.apiFetch('/api/status');
             const status = await response.json();
 
             const progressBar = document.getElementById('progressBar');
@@ -103,7 +106,7 @@ GmailCleaner.Scanner = {
 
             if (status.done) {
                 if (!status.error) {
-                    const resultsResponse = await fetch('/api/results');
+                    const resultsResponse = await GmailCleaner.apiFetch('/api/results');
                     GmailCleaner.results = await resultsResponse.json();
                     this.displayResults();
                     this.updateResultsBadge();
@@ -201,7 +204,7 @@ GmailCleaner.Scanner = {
         btn.textContent = 'Working...';
 
         try {
-            const response = await fetch('/api/unsubscribe', {
+            const response = await GmailCleaner.apiFetch('/api/unsubscribe', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ domain: r.domain, link: r.link })

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -11,8 +11,38 @@ GmailCleaner.UI = {
                 e.preventDefault();
                 const view = item.dataset.view;
                 this.showView(view);
+                this.closeSidebarForMobile();
             });
         });
+
+        const overlay = document.getElementById('sidebarOverlay');
+        if (overlay) {
+            overlay.addEventListener('click', () => this.closeSidebarForMobile());
+            overlay.addEventListener('touchstart', () => this.closeSidebarForMobile(), { passive: true });
+        }
+
+        const closeIfOutside = (event) => {
+            const sidebar = document.getElementById('sidebar');
+            const menuBtn = document.querySelector('.menu-btn');
+            if (!sidebar || !menuBtn) return;
+
+            const isOpen = sidebar.classList.contains('open');
+            if (!isOpen) return;
+
+            const clickedInsideSidebar = sidebar.contains(event.target);
+            const clickedMenuButton = menuBtn.contains(event.target);
+            if (!clickedInsideSidebar && !clickedMenuButton) {
+                this.closeSidebarForMobile();
+            }
+        };
+
+        document.addEventListener('click', closeIfOutside);
+        document.addEventListener('touchstart', closeIfOutside, { passive: true });
+
+        const mainContent = document.querySelector('.main-content');
+        if (mainContent) {
+            mainContent.addEventListener('click', () => this.closeSidebarForMobile());
+        }
     },
 
     showView(viewName) {
@@ -76,7 +106,29 @@ GmailCleaner.UI = {
 
     toggleSidebar() {
         const sidebar = document.getElementById('sidebar');
-        sidebar.classList.toggle('open');
+        const overlay = document.getElementById('sidebarOverlay');
+        const isOpen = sidebar.classList.toggle('open');
+        if (overlay) {
+            overlay.classList.toggle('active', isOpen);
+        }
+        document.body.classList.toggle('sidebar-open', isOpen);
+    },
+
+    closeSidebarForMobile() {
+        const isMobile =
+            window.matchMedia('(max-width: 768px)').matches ||
+            window.matchMedia('(pointer: coarse)').matches;
+        if (!isMobile) return;
+
+        const sidebar = document.getElementById('sidebar');
+        const overlay = document.getElementById('sidebarOverlay');
+        if (sidebar) {
+            sidebar.classList.remove('open');
+        }
+        if (overlay) {
+            overlay.classList.remove('active');
+        }
+        document.body.classList.remove('sidebar-open');
     },
 
     // Toast notification system

--- a/templates/index.html
+++ b/templates/index.html
@@ -460,6 +460,7 @@
     </div>
 
     <!-- Modular JavaScript (cache-busted) -->
+    <script src="/static/js/api.js?v={{ cache_bust }}"></script>
     <script src="/static/js/main.js?v={{ cache_bust }}"></script>
     <script src="/static/js/ui.js?v={{ cache_bust }}"></script>
     <script src="/static/js/auth.js?v={{ cache_bust }}"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -81,6 +81,7 @@
                     </div>
                 </div>
             </aside>
+            <div class="sidebar-overlay" id="sidebarOverlay" onclick="toggleSidebar()"></div>
 
             <!-- Main Content -->
             <main class="main-content">

--- a/tests/unit/api/test_api_actions.py
+++ b/tests/unit/api/test_api_actions.py
@@ -6,6 +6,8 @@ Tests for POST action endpoints.
 
 from unittest.mock import patch
 
+from app.core.state import SessionState
+
 # client fixture is provided by conftest.py
 
 
@@ -160,7 +162,10 @@ class TestDeleteEmailsEndpoint:
             "/api/delete-emails", json={"sender": "newsletter@example.com"}
         )
         assert response.status_code == 200
-        mock_delete.assert_called_once_with("newsletter@example.com")
+        mock_delete.assert_called_once()
+        args, _ = mock_delete.call_args
+        assert isinstance(args[0], SessionState)
+        assert args[1] == "newsletter@example.com"
 
 
 class TestDeleteBulkEndpoint:
@@ -173,7 +178,10 @@ class TestDeleteBulkEndpoint:
         response = client.post("/api/delete-emails-bulk", json={"senders": senders})
         assert response.status_code == 200
         assert response.json() == {"status": "started"}
-        mock_delete.assert_called_once_with(senders)
+        mock_delete.assert_called_once()
+        args, _ = mock_delete.call_args
+        assert isinstance(args[0], SessionState)
+        assert args[1] == senders
 
     def test_delete_bulk_large_senders_list(self, client):
         """POST /api/delete-emails-bulk with many senders should succeed (no limit)."""
@@ -188,7 +196,10 @@ class TestDeleteBulkEndpoint:
         response = client.post("/api/delete-emails-bulk", json={"senders": []})
         assert response.status_code == 200
         assert response.json() == {"status": "started"}
-        mock_delete.assert_called_once_with([])
+        mock_delete.assert_called_once()
+        args, _ = mock_delete.call_args
+        assert isinstance(args[0], SessionState)
+        assert args[1] == []
 
 
 class TestRequestValidation:

--- a/tests/unit/services/auth/test_oauth_flow_complete.py
+++ b/tests/unit/services/auth/test_oauth_flow_complete.py
@@ -10,6 +10,23 @@ from app.core.state import SessionState
 from app.services import auth
 
 
+def exists_side_effect(path):
+    """
+    Simulates os.path.exists behavior for tests by indicating presence only for credentials files.
+    
+    Parameters:
+        path (str | os.PathLike): Path or filename to check.
+    
+    Returns:
+        True if `path` contains "credentials.json", False otherwise (including when it contains "token.json").
+    """
+    if "token.json" in str(path):
+        return False
+    if "credentials.json" in str(path):
+        return True
+    return False
+
+
 class ImmediateThread:
     """Run thread targets immediately in tests."""
 
@@ -92,22 +109,6 @@ class TestSuccessfulOAuthFlow:
         mock_settings.oauth_host = "localhost"
         mock_settings.oauth_external_port = None
 
-        def exists_side_effect(path):
-            """
-            Simulates os.path.exists behavior for tests by indicating presence only for credentials files.
-            
-            Parameters:
-                path (str | os.PathLike): Path or filename to check.
-            
-            Returns:
-                True if `path` contains "credentials.json", False otherwise (including when it contains "token.json").
-            """
-            if "token.json" in str(path):
-                return False
-            if "credentials.json" in str(path):
-                return True
-            return False
-
         mock_exists.side_effect = exists_side_effect
         mock_is_file_empty.return_value = False
 
@@ -147,13 +148,6 @@ class TestSuccessfulOAuthFlow:
         mock_settings.scopes = ["scope1", "scope2"]
         mock_settings.oauth_port = 8767
         mock_settings.oauth_host = "localhost"
-
-        def exists_side_effect(path):
-            if "token.json" in str(path):
-                return False
-            if "credentials.json" in str(path):
-                return True
-            return False
 
         mock_exists.side_effect = exists_side_effect
 
@@ -199,22 +193,6 @@ class TestSuccessfulOAuthFlow:
         mock_settings.oauth_host = "localhost"
         mock_settings.oauth_external_port = None
 
-        def exists_side_effect(path):
-            """
-            Simulates os.path.exists behavior for tests by indicating presence only for credentials files.
-            
-            Parameters:
-                path (str | os.PathLike): Path or filename to check.
-            
-            Returns:
-                True if `path` contains "credentials.json", False otherwise (including when it contains "token.json").
-            """
-            if "token.json" in str(path):
-                return False
-            if "credentials.json" in str(path):
-                return True
-            return False
-
         mock_exists.side_effect = exists_side_effect
 
         mock_flow_instance = Mock()
@@ -258,22 +236,6 @@ class TestSuccessfulOAuthFlow:
         mock_settings.oauth_port = 8767
         mock_settings.oauth_host = "custom.example.com"
         mock_settings.oauth_external_port = None
-
-        def exists_side_effect(path):
-            """
-            Simulates os.path.exists behavior for tests by indicating presence only for credentials files.
-            
-            Parameters:
-                path (str | os.PathLike): Path or filename to check.
-            
-            Returns:
-                True if `path` contains "credentials.json", False otherwise (including when it contains "token.json").
-            """
-            if "token.json" in str(path):
-                return False
-            if "credentials.json" in str(path):
-                return True
-            return False
 
         mock_exists.side_effect = exists_side_effect
 
@@ -325,13 +287,6 @@ class TestOAuthFlowErrors:
         mock_settings.oauth_port = 8767
         mock_settings.oauth_host = "localhost"
 
-        def exists_side_effect(path):
-            if "token.json" in str(path):
-                return False
-            if "credentials.json" in str(path):
-                return True
-            return False
-
         mock_exists.side_effect = exists_side_effect
 
         # Mock Flow to raise error for invalid code
@@ -374,13 +329,6 @@ class TestOAuthFlowErrors:
         mock_settings.oauth_port = 8767
         mock_settings.oauth_host = "localhost"
 
-        def exists_side_effect(path):
-            if "token.json" in str(path):
-                return False
-            if "credentials.json" in str(path):
-                return True
-            return False
-
         mock_exists.side_effect = exists_side_effect
 
         mock_flow_instance = Mock()
@@ -420,13 +368,6 @@ class TestOAuthFlowErrors:
         mock_settings.scopes = ["scope1", "scope2"]
         mock_settings.oauth_port = 8767
         mock_settings.oauth_host = "localhost"
-
-        def exists_side_effect(path):
-            if "token.json" in str(path):
-                return False
-            if "credentials.json" in str(path):
-                return True
-            return False
 
         mock_exists.side_effect = exists_side_effect
 

--- a/tests/unit/services/auth/test_oauth_flow_complete.py
+++ b/tests/unit/services/auth/test_oauth_flow_complete.py
@@ -70,8 +70,7 @@ class ImmediateThread:
             self._target(*self._args, **self._kwargs)
 
     def join(self, timeout=None):
-        _ = timeout
-        return None
+        pass
 
 
 class TestSuccessfulOAuthFlow:

--- a/tests/unit/services/auth/test_oauth_flow_complete.py
+++ b/tests/unit/services/auth/test_oauth_flow_complete.py
@@ -194,7 +194,6 @@ class TestSuccessfulOAuthFlow:
         mock_settings.oauth_port = 8767
         mock_settings.oauth_host = "localhost"
         mock_settings.oauth_external_port = None
-        mock_settings.oauth_external_port = None
 
         def exists_side_effect(path):
             """

--- a/tests/unit/services/auth/test_oauth_flow_complete.py
+++ b/tests/unit/services/auth/test_oauth_flow_complete.py
@@ -6,8 +6,51 @@ Tests for successful OAuth flows and edge cases not covered in existing tests.
 
 from unittest.mock import Mock, patch, mock_open
 
-
+from app.core.state import SessionState
 from app.services import auth
+
+
+class ImmediateThread:
+    """Run thread targets immediately in tests."""
+
+    def __init__(self, *args, **kwargs):
+        """
+        Initialize an ImmediateThread-like object by recording a callable target, its positional and keyword arguments, and a daemon flag.
+        
+        Parameters:
+            *args: Optional positional form (target, args, kwargs) where:
+                - target (callable): the callable to invoke when started.
+                - args (tuple): positional arguments to pass to the target.
+                - kwargs (dict): keyword arguments to pass to the target.
+            **kwargs: Keyword-based initialization keys:
+                - target (callable): callable to invoke (overrides positional target if provided).
+                - args (tuple): positional arguments to pass to the target (defaults to ()).
+                - kwargs (dict): keyword arguments to pass to the target (defaults to {}).
+                - daemon (bool): whether the thread is a daemon (defaults to False).
+        
+        Behavior:
+            - If `target`, `args`, or `kwargs` are provided via keywords, those values are used.
+            - If no keyword `target` is given but positional `*args` are supplied, the constructor derives `target`, `args`, and `kwargs` from the positional values in order.
+        """
+        self._target = kwargs.get("target")
+        self._args = kwargs.get("args", ())
+        self._kwargs = kwargs.get("kwargs", {})
+        self.daemon = kwargs.get("daemon", False)
+        if self._target is None and args:
+            self._target = args[0]
+            if len(args) > 1:
+                self._args = args[1]
+            if len(args) > 2:
+                self._kwargs = args[2]
+
+    def start(self):
+        """
+        Execute the stored target callable immediately in the current thread.
+        
+        If no target was provided, this method does nothing.
+        """
+        if self._target:
+            self._target(*self._args, **self._kwargs)
 
 
 class TestSuccessfulOAuthFlow:
@@ -33,14 +76,28 @@ class TestSuccessfulOAuthFlow:
         mock_is_file_empty,
         mock_settings,
     ):
-        """Complete OAuth flow should save token successfully."""
+        """
+        Verifies that starting the complete OAuth flow when credentials exist and no token is present saves a new token and reports that sign-in has started.
+        
+        Sets up credentials present and token absent, mocks a successful InstalledAppFlow returning credentials with a token, then calls get_gmail_service and asserts that no service is returned immediately, an error message is returned, and the error contains "Sign-in started".
+        """
         mock_settings.credentials_file = "credentials.json"
         mock_settings.token_file = "token.json"
         mock_settings.scopes = ["scope1", "scope2"]
         mock_settings.oauth_port = 8767
         mock_settings.oauth_host = "localhost"
+        mock_settings.oauth_external_port = None
 
         def exists_side_effect(path):
+            """
+            Simulates os.path.exists behavior for tests by indicating presence only for credentials files.
+            
+            Parameters:
+                path (str | os.PathLike): Path or filename to check.
+            
+            Returns:
+                True if `path` contains "credentials.json", False otherwise (including when it contains "token.json").
+            """
             if "token.json" in str(path):
                 return False
             if "credentials.json" in str(path):
@@ -98,14 +155,24 @@ class TestSuccessfulOAuthFlow:
 
         mock_flow_instance = Mock()
         mock_flow.from_client_secrets_file.return_value = mock_flow_instance
-        mock_flow_instance.run_local_server.return_value = Mock()
+        mock_flow_instance.authorization_url.return_value = (
+            "http://auth.example.com",
+            "state",
+        )
 
-        service, error = auth.get_gmail_service()
+        with patch(
+            "app.services.auth.HTTPServer", side_effect=OSError("port error")
+        ) as mock_server, patch(
+            "app.services.auth.threading.Thread", new=ImmediateThread
+        ):
+            service, error = auth.get_gmail_service(session=SessionState())
 
         # Verify bind_address is 0.0.0.0 for web auth mode
-        mock_flow_instance.run_local_server.assert_called_once()
-        call_kwargs = mock_flow_instance.run_local_server.call_args[1]
-        assert call_kwargs.get("bind_addr") == "0.0.0.0"
+        assert service is None
+        assert error is not None
+        mock_server.assert_called_once()
+        bind_address = mock_server.call_args[0][0][0]
+        assert bind_address == "0.0.0.0"
 
     @patch("app.services.auth.settings")
     @patch("os.path.exists")
@@ -126,8 +193,19 @@ class TestSuccessfulOAuthFlow:
         mock_settings.scopes = ["scope1", "scope2"]
         mock_settings.oauth_port = 8767
         mock_settings.oauth_host = "localhost"
+        mock_settings.oauth_external_port = None
+        mock_settings.oauth_external_port = None
 
         def exists_side_effect(path):
+            """
+            Simulates os.path.exists behavior for tests by indicating presence only for credentials files.
+            
+            Parameters:
+                path (str | os.PathLike): Path or filename to check.
+            
+            Returns:
+                True if `path` contains "credentials.json", False otherwise (including when it contains "token.json").
+            """
             if "token.json" in str(path):
                 return False
             if "credentials.json" in str(path):
@@ -138,14 +216,24 @@ class TestSuccessfulOAuthFlow:
 
         mock_flow_instance = Mock()
         mock_flow.from_client_secrets_file.return_value = mock_flow_instance
-        mock_flow_instance.run_local_server.return_value = Mock()
+        mock_flow_instance.authorization_url.return_value = (
+            "http://auth.example.com",
+            "state",
+        )
 
-        service, error = auth.get_gmail_service()
+        with patch(
+            "app.services.auth.HTTPServer", side_effect=OSError("port error")
+        ) as mock_server, patch(
+            "app.services.auth.threading.Thread", new=ImmediateThread
+        ):
+            service, error = auth.get_gmail_service(session=SessionState())
 
         # Verify bind_address is localhost for desktop mode
-        mock_flow_instance.run_local_server.assert_called_once()
-        call_kwargs = mock_flow_instance.run_local_server.call_args[1]
-        assert call_kwargs.get("bind_addr") == "localhost"
+        assert service is None
+        assert error is not None
+        mock_server.assert_called_once()
+        bind_address = mock_server.call_args[0][0][0]
+        assert bind_address == "localhost"
 
     @patch("app.services.auth.settings")
     @patch("os.path.exists")
@@ -166,8 +254,18 @@ class TestSuccessfulOAuthFlow:
         mock_settings.scopes = ["scope1", "scope2"]
         mock_settings.oauth_port = 8767
         mock_settings.oauth_host = "custom.example.com"
+        mock_settings.oauth_external_port = None
 
         def exists_side_effect(path):
+            """
+            Simulates os.path.exists behavior for tests by indicating presence only for credentials files.
+            
+            Parameters:
+                path (str | os.PathLike): Path or filename to check.
+            
+            Returns:
+                True if `path` contains "credentials.json", False otherwise (including when it contains "token.json").
+            """
             if "token.json" in str(path):
                 return False
             if "credentials.json" in str(path):
@@ -178,14 +276,20 @@ class TestSuccessfulOAuthFlow:
 
         mock_flow_instance = Mock()
         mock_flow.from_client_secrets_file.return_value = mock_flow_instance
-        mock_flow_instance.run_local_server.return_value = Mock()
+        mock_flow_instance.authorization_url.return_value = (
+            "http://auth.example.com",
+            "state",
+        )
 
-        service, error = auth.get_gmail_service()
+        with patch(
+            "app.services.auth.HTTPServer", side_effect=OSError("port error")
+        ), patch("app.services.auth.threading.Thread", new=ImmediateThread):
+            service, error = auth.get_gmail_service(session=SessionState())
 
         # Verify custom host is used
-        mock_flow_instance.run_local_server.assert_called_once()
-        call_kwargs = mock_flow_instance.run_local_server.call_args[1]
-        assert call_kwargs.get("host") == "custom.example.com"
+        assert service is None
+        assert error is not None
+        assert mock_flow_instance.redirect_uri == "http://custom.example.com:8767/"
 
 
 class TestOAuthFlowErrors:

--- a/tests/unit/services/auth/test_oauth_flow_complete.py
+++ b/tests/unit/services/auth/test_oauth_flow_complete.py
@@ -53,6 +53,7 @@ class ImmediateThread:
             self._target(*self._args, **self._kwargs)
 
     def join(self, timeout=None):
+        _ = timeout
         return None
 
 

--- a/tests/unit/services/auth/test_oauth_flow_complete.py
+++ b/tests/unit/services/auth/test_oauth_flow_complete.py
@@ -52,6 +52,9 @@ class ImmediateThread:
         if self._target:
             self._target(*self._args, **self._kwargs)
 
+    def join(self, timeout=None):
+        return None
+
 
 class TestSuccessfulOAuthFlow:
     """Tests for successful OAuth flow scenarios"""

--- a/tests/unit/services/auth/test_token_management_complete.py
+++ b/tests/unit/services/auth/test_token_management_complete.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, patch, mock_open
 
 from google.oauth2.credentials import Credentials
 
+from app.core.state import SessionState
 from app.services import auth
 
 
@@ -58,7 +59,7 @@ class TestTokenCreationAndStorage:
         mock_creds.to_json.return_value = '{"token": "access_token", "refresh_token": "refresh_token", "scopes": ["scope1", "scope2"]}'
         mock_flow_instance.run_local_server.return_value = mock_creds
 
-        service, error = auth.get_gmail_service()
+        service, error = auth.get_gmail_service(session=SessionState())
 
         # OAuth runs in background thread, so we verify the structure
         assert service is None
@@ -141,7 +142,7 @@ class TestTokenCreationAndStorage:
         mock_service.users.return_value.getProfile.return_value = mock_profile
         mock_build.return_value = mock_service
 
-        service, error = auth.get_gmail_service()
+        service, error = auth.get_gmail_service(session=SessionState())
 
         # Verify refresh was called
         assert mock_creds.refresh.called
@@ -220,7 +221,7 @@ class TestTokenValidation:
         mock_service.users.return_value.getProfile.return_value = mock_profile
         mock_build.return_value = mock_service
 
-        service, error = auth.get_gmail_service()
+        service, error = auth.get_gmail_service(session=SessionState())
 
         # Should refresh and return service
         assert mock_creds.refresh.called
@@ -246,7 +247,7 @@ class TestTokenValidation:
 
         mock_creds_class.from_authorized_user_file.return_value = mock_creds
 
-        result = auth.needs_auth_setup()
+        result = auth.needs_auth_setup(session=SessionState())
 
         assert result is True
 
@@ -271,7 +272,7 @@ class TestTokenFileErrors:
             "Invalid token file format"
         )
 
-        result = auth.needs_auth_setup()
+        result = auth.needs_auth_setup(session=SessionState())
 
         assert result is True
 
@@ -292,7 +293,7 @@ class TestTokenFileErrors:
             "Invalid JSON"
         )
 
-        result = auth.needs_auth_setup()
+        result = auth.needs_auth_setup(session=SessionState())
 
         assert result is True
 
@@ -312,7 +313,7 @@ class TestTokenFileErrors:
             "Permission denied"
         )
 
-        result = auth.needs_auth_setup()
+        result = auth.needs_auth_setup(session=SessionState())
 
         assert result is True
 
@@ -364,7 +365,7 @@ class TestTokenFileErrors:
             mock_service.users.return_value.getProfile.return_value = mock_profile
             mock_build.return_value = mock_service
 
-            service, error = auth.get_gmail_service()
+            service, error = auth.get_gmail_service(session=SessionState())
 
             # Should handle write failure gracefully - creds are still valid after refresh
             # so service should be returned despite write failure


### PR DESCRIPTION
## Description

- Move auth/session state to the client: tokens now live per browser (localStorage) and are sent on each request via "X-Session-Id" / "X-Auth-Token", enabling multi‑user usage without a shared server token.
- Add session-aware API context to read tokens per request and keep token-file persistence only when no client session is provided.
- Update auth flow to always run the manual web flow and expose the pending OAuth URL so the client can open it (works in Docker/headless).
- Build OAuth redirect using the request host / forwarded host + scheme, so callbacks use the same domain/IP the user is visiting (no forced localhost).
- Improve mobile experience: responsive sidebar overlay + close behavior, mobile layout fixes, and better handling of results overflow.
- Update README to document the new web auth flow, popup/log fallback, and session storage behavior.

## Checklist

- [x] I have tested my changes locally
- [x] Docker build works (if modified)

## Related Issues

N/A, I just wanted to help because I really like this project and I want to be part of it :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- State/model: Replaced global AppState with per-session SessionState and a SessionStore; added get_session_state and a module-level default via get_session_state("default").
- Request context: Added SessionContext dataclass and get_session_context dependency; many FastAPI routes now accept ctx: SessionContext = Depends(...) and use ctx.session and ctx.token_json.
- Auth/session: Tokens moved to client-side localStorage and sent on each request via X-Session-Id and X-Auth-Token; server token-file persistence retained only as a fallback and gated by session.allow_token_file.
- OAuth flow: Always uses the manual web flow, exposes a pending OAuth URL for the client to open (supports Docker/headless); redirect is built from request host / X-Forwarded-Host + scheme so callbacks use the same domain/IP the user visits; per-session OAuth state with auth_in_progress guard and per-session callback handling.
- Services refactor: Auth and Gmail service modules refactored to accept SessionState (and optional token_json, oauth_host, oauth_scheme) instead of global state; many public function signatures across app/services/* updated to take session.
- API changes: Route handlers updated to depend on get_session_context and pass ctx.session into service/background tasks; added helper _get_request_host_and_scheme to derive host and scheme from requests.
- Frontend: Added static/js/api.js with GmailCleaner.Session (session ID and token helpers) and GmailCleaner.apiFetch; frontend scripts switched to apiFetch and store/restore token_json from localStorage; auth polling flow added to open pending OAuth URLs.
- UI / mobile: Responsive CSS and JS improvements (mobile sidebar overlay, close-on-outside-click, mobile layout fixes, results overflow handling); templates/index.html adds a sidebar overlay and includes api.js (duplicated include present).
- Docs: README reorganized and expanded to document the new web auth flow, popup/log fallback, per-browser localStorage session behavior, optional token-file persistence, OAUTH_HOST/reverse-proxy guidance, docker-compose override examples, and updated Docker log/troubleshooting instructions.
- Tests: Unit tests updated for session-aware signatures (tests now expect SessionState as first arg or pass SessionState into auth/service calls); added ImmediateThread and file-exists side-effect helpers for OAuth tests; minor test/lint fixes.
- Misc: .gitignore now ignores .venv/; several endpoints' error-handling/messages adjusted; module imports updated (core.__init__ uses get_session_state).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->