### PR TITLE
Claude/investigate gmail cleaner uzbi9

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,16 +1,5 @@
-# GitHub authenticates as you when using ${{ secrets.GITHUB_TOKEN }}.
-# Improve this workflow security with a GitHub PAT. Make one with the "Note" as GHCR_GMAIL_CLEANER_PAT here:
-# https://github.com/settings/tokens
-# then check the following permissions:
-#  repo
-#   ...
-#  workflow
-#  write:packages
-#   ...
-# Click generate, <copy to clipboard>
-# You just created a PAT
-# visit your repo, Settings -> Secrets & Variables -> Actions -> Repo Secrets -> New
-# Name: GHCR_GMAIL_CLEANER_PAT; Secret: <paste from clipboard>
+# Builds multi-arch Docker images and pushes to GitHub Container Registry (ghcr.io).
+# Uses the built-in GITHUB_TOKEN with packages:write permission — no PAT needed.
 
 name: Build and Publish Docker images
 
@@ -33,6 +22,9 @@ jobs:
   # define the job to build and publish docker images
   build-and-push-docker-images:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     # steps to perform in the job
     steps:
@@ -63,7 +55,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_GMAIL_CLEANER_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # https://github.com/docker/build-push-action
       - name: Build and push image to GitHub Container Registry

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -23,6 +23,7 @@ name: Build and Publish Docker images
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io

--- a/app/services/gmail/scan.py
+++ b/app/services/gmail/scan.py
@@ -88,6 +88,7 @@ def scan_emails(limit: int = 500, filters: Optional[dict] = None):
                 "email": "",
                 "first_date": None,
                 "last_date": None,
+                "message_ids": [],
             }
         )
         processed = 0
@@ -124,6 +125,9 @@ def scan_emails(limit: int = 500, filters: Optional[dict] = None):
                 unsubscribe_data[domain]["email"] = sender_email
                 if len(unsubscribe_data[domain]["subjects"]) < 3:
                     unsubscribe_data[domain]["subjects"].append(subject)
+                    unsubscribe_data[domain]["message_ids"].append(
+                        response.get("id", "")
+                    )
 
                 # Track first and last dates (parse dates for accurate comparison)
                 if email_date:
@@ -210,6 +214,7 @@ def scan_emails(limit: int = 500, filters: Optional[dict] = None):
                     "email": v.get("email", ""),
                     "first_date": v.get("first_date"),
                     "last_date": v.get("last_date"),
+                    "message_ids": v.get("message_ids", []),
                 }
                 for k, v in unsubscribe_data.items()
             ],

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -317,6 +317,41 @@
     white-space: nowrap;
 }
 
+/* Gmail "Open in Gmail" subject link */
+.subject-gmail-link {
+    color: var(--text-secondary);
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.subject-gmail-link:hover {
+    color: var(--primary-color);
+    text-decoration: underline;
+}
+
+.gmail-link-icon {
+    display: inline-block;
+    font-size: 12px;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+    flex-shrink: 0;
+    margin-left: 2px;
+}
+
+.result-item:hover .gmail-link-icon {
+    opacity: 0.7;
+}
+
+.subject-gmail-link:hover .gmail-link-icon {
+    opacity: 1;
+}
+
 .result-count {
     background: var(--hover-bg);
     color: var(--text-secondary);

--- a/static/css/responsive.css
+++ b/static/css/responsive.css
@@ -116,6 +116,10 @@
         width: 100%;
     }
 
+    .gmail-link-icon {
+        opacity: 0.5;
+    }
+
     .result-actions {
         width: 100%;
         margin-left: 0;

--- a/static/js/delete.js
+++ b/static/js/delete.js
@@ -166,7 +166,10 @@ GmailCleaner.Delete = {
                 </label>
                 <div class="result-content">
                     <div class="result-sender">${GmailCleaner.UI.escapeHtml(r.email)}</div>
-                    <div class="result-subject">${GmailCleaner.UI.escapeHtml(r.subjects[0] || 'No subject')}</div>
+                    <div class="result-subject">${r.message_ids && r.message_ids[0]
+                        ? `<a href="https://mail.google.com/mail/u/0/#all/${encodeURIComponent(r.message_ids[0])}" target="_blank" rel="noopener noreferrer" class="subject-gmail-link" title="Open in Gmail">${GmailCleaner.UI.escapeHtml(r.subjects[0] || 'No subject')}<span class="gmail-link-icon" aria-hidden="true">\u2197</span></a>`
+                        : GmailCleaner.UI.escapeHtml(r.subjects[0] || 'No subject')
+                    }</div>
                     <div class="result-meta">
                         ${dateRangeDisplay}
                         <span class="result-count">${r.count} emails</span>

--- a/static/js/scanner.js
+++ b/static/js/scanner.js
@@ -179,7 +179,10 @@ GmailCleaner.Scanner = {
                 </label>
                 <div class="result-content">
                     <div class="result-sender">${GmailCleaner.UI.escapeHtml(r.domain)} ${typeLabel}</div>
-                    <div class="result-subject">${GmailCleaner.UI.escapeHtml(r.subjects[0] || 'No subject')}</div>
+                    <div class="result-subject">${r.message_ids && r.message_ids[0]
+                        ? `<a href="https://mail.google.com/mail/u/0/#all/${encodeURIComponent(r.message_ids[0])}" target="_blank" rel="noopener noreferrer" class="subject-gmail-link" title="Open in Gmail">${GmailCleaner.UI.escapeHtml(r.subjects[0] || 'No subject')}<span class="gmail-link-icon" aria-hidden="true">\u2197</span></a>`
+                        : GmailCleaner.UI.escapeHtml(r.subjects[0] || 'No subject')
+                    }</div>
                 </div>
                 <div class="result-meta">
                     ${r.first_date && r.last_date ? `<div class="result-date-range">${GmailCleaner.Scanner.formatDateRange(r.first_date, r.last_date)}</div>` : ''}


### PR DESCRIPTION
## Description

Simplify the Docker build workflow CI configuration:

- **Switch from PAT to `GITHUB_TOKEN`** for GHCR authentication. Fine-grained PATs don't support GitHub Packages, and a classic PAT is unnecessary overhead. The built-in `GITHUB_TOKEN` with explicit `packages: write` permission works out of the box with zero secret setup.
- **Add `workflow_dispatch` trigger** so builds can be run manually from the Actions tab without creating a release.

## Checklist
- [x] I have tested my changes locally
- [ ] Docker build works (if modified)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Workflow Updates
- Switched Docker build workflow authentication from PAT-based to built-in GITHUB_TOKEN with explicit `packages: write` permission, eliminating the need for secret setup
- Added `workflow_dispatch` trigger to enable manual builds from the GitHub Actions tab

## Backend Changes
- Added message ID tracking in the Gmail scan service by storing message IDs per unsubscribe domain, populated during the unsubscribe scanning process and included in final results

## Frontend UI Enhancements
- Implemented clickable "Open in Gmail" links for message subjects in both delete and scanner list views
- Links open the corresponding Gmail thread in a new tab when a message ID is available
- Added hover-revealed Gmail icon indicator for linked subjects
- Added CSS styling for the Gmail link component with hover effects
- Added responsive styling for the Gmail icon on mobile devices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->