### PR TITLE
Add filter for attachments

### DIFF
--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -34,6 +34,9 @@ class FiltersModel(BaseModel):
         description="Filter emails from specific sender (email address or domain)",
     )
     label: Optional[str] = Field(default=None, description="Gmail label filter")
+    has_attachment: Optional[str] = Field(
+        default=None, description="Filter by attachment: 'has' or 'none'"
+    )
 
     @field_validator("older_than")
     @classmethod
@@ -94,6 +97,15 @@ class FiltersModel(BaseModel):
         if "@" not in sender and "." not in sender:
             raise ValueError("sender must be a valid email address or domain")
         return sender
+
+    @field_validator("has_attachment")
+    @classmethod
+    def validate_has_attachment(cls, v) -> Optional[str]:
+        if v is None or v == "":
+            return None
+        if v not in ("has", "none"):
+            raise ValueError('has_attachment must be "has" or "none"')
+        return v
 
 
 # ----- Request Models -----

--- a/app/services/gmail/helpers.py
+++ b/app/services/gmail/helpers.py
@@ -137,6 +137,12 @@ def build_gmail_query(filters: Optional[Union[dict, Any]] = None) -> str:
     if label := filters.get("label", ""):
         query_parts.append(f"label:{label}")
 
+    has_attachment = filters.get("has_attachment", "")
+    if has_attachment == "has":
+        query_parts.append("has:attachment")
+    elif has_attachment == "none":
+        query_parts.append("-has:attachment")
+
     return " ".join(query_parts)
 
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -165,7 +165,7 @@
                         </svg>
                     </div>
                     <h3 class="text-xl font-bold text-[#222222] mb-3">Smart Filters</h3>
-                    <p class="text-[#6B7A8F] leading-relaxed">Filter by age (7d, 30d, 90d), size (1MB, 5MB, 10MB), and category (Promotions, Social, Updates).</p>
+                    <p class="text-[#6B7A8F] leading-relaxed">Filter by age (7d, 30d, 90d), size (1MB, 5MB, 10MB), category (Promotions, Social, Updates), label and has or doesn't have attachment.</p>
                 </div>
 
                 <!-- Feature 5 -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -165,7 +165,7 @@
                         </svg>
                     </div>
                     <h3 class="text-xl font-bold text-[#222222] mb-3">Smart Filters</h3>
-                    <p class="text-[#6B7A8F] leading-relaxed">Filter by age (7d, 30d, 90d), size (1MB, 5MB, 10MB), category (Promotions, Social, Updates), label and has or doesn't have attachment.</p>
+                    <p class="text-[#6B7A8F] leading-relaxed">Filter by age (7d, 30d, 90d), size (1MB, 5MB, 10MB), category (Promotions, Social, Updates), label, and attachment presence.</p>
                 </div>
 
                 <!-- Feature 5 -->

--- a/static/js/filters.js
+++ b/static/js/filters.js
@@ -134,6 +134,7 @@ GmailCleaner.Filters = {
         const category = document.getElementById('filterCategory')?.value || '';
         const sender = document.getElementById('filterSender')?.value?.trim() || '';
         const label = document.getElementById('filterLabel')?.value || '';
+        const hasAttachment = document.getElementById('filterAttachment')?.value || '';
 
         return {
             older_than: olderThan,
@@ -142,7 +143,8 @@ GmailCleaner.Filters = {
             larger_than: largerThan,
             category: category,
             sender: sender,
-            label: label
+            label: label,
+            has_attachment: hasAttachment
         };
     },
 
@@ -152,6 +154,7 @@ GmailCleaner.Filters = {
         const category = document.getElementById('filterCategory');
         const sender = document.getElementById('filterSender');
         const label = document.getElementById('filterLabel');
+        const attachment = document.getElementById('filterAttachment');
         const dateRangeGroup = document.getElementById('dateRangeGroup');
 
         if (olderThan) olderThan.value = '';
@@ -159,6 +162,7 @@ GmailCleaner.Filters = {
         if (category) category.value = '';
         if (sender) sender.value = '';
         if (label) label.value = '';
+        if (attachment) attachment.value = '';
 
         // Clear date picker
         if (this.litepicker) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -143,6 +143,14 @@
                                 <!-- Populated by JavaScript after sign-in -->
                             </select>
                         </div>
+                        <div class="filter-group">
+                            <label for="filterAttachment">Attachments</label>
+                            <select id="filterAttachment" class="filter-select">
+                                <option value="">Any</option>
+                                <option value="has">Has attachment</option>
+                                <option value="none">No attachment</option>
+                            </select>
+                        </div>
                         <button class="filter-clear-btn" id="filterClearBtn" title="Clear all filters">
                             <svg viewBox="0 0 24 24" width="16" height="16">
                                 <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>


### PR DESCRIPTION
## Description

This adds a filter for whether emails have or do not have attachments, with the default option of "Any"

## Checklist

- [x] I have tested my changes locally
- [x] Docker build works (if modified)

## Related Issues

Fixes #99 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added attachment-based filtering to Gmail Cleaner allowing filters: Any (default), Has attachment, No attachment.
- Backend: added optional has_attachment field to FiltersModel (app/models/schemas.py) with validator enforcing allowed values ("has" or "none").
- Query builder: build_gmail_query() (app/services/gmail/helpers.py) maps has_attachment to Gmail syntax (has:attachment or -has:attachment).
- Frontend: UI dropdown for attachment filter added to templates/index.html.
- Client-side: static/js/filters.js updated to include has_attachment in filter payload and to reset the attachment control.
- Docs: docs/index.html updated to mention attachment presence in Smart Filters.
- Fixes issue #99.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->