### PR TITLE
Support inbox-only filters, prevent 429s from Google getting in the w…

### DIFF
--- a/app/api/actions.py
+++ b/app/api/actions.py
@@ -118,7 +118,7 @@ async def api_delete_emails(request: DeleteEmailsRequest):
             detail="Sender email is required",
         )
     try:
-        return delete_emails_by_sender(request.sender)
+        return delete_emails_by_sender(request.sender, request.mail_scope)
     except Exception as e:
         logger.exception("Error deleting emails")
         raise HTTPException(
@@ -132,7 +132,9 @@ async def api_delete_emails_bulk(
     request: DeleteBulkRequest, background_tasks: BackgroundTasks
 ):
     """Delete emails from multiple senders (background task with progress)."""
-    background_tasks.add_task(delete_emails_bulk_background, request.senders)
+    background_tasks.add_task(
+        delete_emails_bulk_background, request.senders, request.mail_scope
+    )
     return {"status": "started"}
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ Main application factory and configuration.
 """
 
 import hashlib
+import os
 import subprocess
 import time
 from contextlib import asynccontextmanager
@@ -17,6 +18,32 @@ from app.core import settings
 from app.api import status_router, actions_router
 
 templates = Jinja2Templates(directory="templates")
+
+
+def get_asset_hash() -> str | None:
+    """Hash served frontend assets so Docker builds without git still bust caches."""
+    asset_paths = []
+    for directory in ("static", "templates"):
+        if not os.path.isdir(directory):
+            continue
+        for root, _dirs, files in os.walk(directory):
+            for file_name in files:
+                if file_name.endswith((".css", ".html", ".js")):
+                    asset_paths.append(os.path.join(root, file_name))
+
+    if not asset_paths:
+        return None
+
+    hasher = hashlib.sha256()
+    for file_path in sorted(asset_paths):
+        hasher.update(file_path.encode())
+        try:
+            with open(file_path, "rb") as f:
+                hasher.update(f.read())
+        except OSError:
+            pass
+
+    return hasher.hexdigest()[:8]
 
 
 def get_cache_bust_value() -> str:
@@ -99,6 +126,11 @@ def get_cache_bust_value() -> str:
     # If we have a base value (commit hash), use it
     if base_value:
         return base_value
+
+    # Docker images may not contain .git, so use frontend asset content.
+    asset_hash = get_asset_hash()
+    if asset_hash:
+        return asset_hash
 
     # Fall back to app version
     if settings.app_version:

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -34,6 +34,9 @@ class FiltersModel(BaseModel):
         description="Filter emails from specific sender (email address or domain)",
     )
     label: Optional[str] = Field(default=None, description="Gmail label filter")
+    mail_scope: Optional[str] = Field(
+        default="inbox", description="Mail scope: inbox or all"
+    )
 
     @field_validator("older_than")
     @classmethod
@@ -95,6 +98,16 @@ class FiltersModel(BaseModel):
             raise ValueError("sender must be a valid email address or domain")
         return sender
 
+    @field_validator("mail_scope")
+    @classmethod
+    def validate_mail_scope(cls, v) -> str:
+        if v is None or v == "":
+            return "inbox"
+        value = v.strip().lower()
+        if value not in ("inbox", "all"):
+            raise ValueError('mail_scope must be either "inbox" or "all"')
+        return value
+
 
 # ----- Request Models -----
 
@@ -142,12 +155,34 @@ class DeleteEmailsRequest(BaseModel):
     """Request to delete emails from a sender."""
 
     sender: str = Field(default="", description="Sender email address")
+    mail_scope: str = Field(default="inbox", description="Mail scope: inbox or all")
+
+    @field_validator("mail_scope")
+    @classmethod
+    def validate_mail_scope(cls, v) -> str:
+        if v is None or v == "":
+            return "inbox"
+        value = v.strip().lower()
+        if value not in ("inbox", "all"):
+            raise ValueError('mail_scope must be either "inbox" or "all"')
+        return value
 
 
 class DeleteBulkRequest(BaseModel):
     """Request to delete emails from multiple senders."""
 
     senders: list[str] = Field(default=[], description="List of sender addresses")
+    mail_scope: str = Field(default="inbox", description="Mail scope: inbox or all")
+
+    @field_validator("mail_scope")
+    @classmethod
+    def validate_mail_scope(cls, v) -> str:
+        if v is None or v == "":
+            return "inbox"
+        value = v.strip().lower()
+        if value not in ("inbox", "all"):
+            raise ValueError('mail_scope must be either "inbox" or "all"')
+        return value
 
 
 class DownloadEmailsRequest(BaseModel):

--- a/app/services/gmail/delete.py
+++ b/app/services/gmail/delete.py
@@ -17,6 +17,26 @@ from app.services.gmail.helpers import build_gmail_query, get_sender_info, get_s
 logger = logging.getLogger(__name__)
 
 
+def _get_mail_scope(filters: Optional[dict] = None) -> str:
+    if not filters:
+        return "inbox"
+    return "all" if filters.get("mail_scope") == "all" else "inbox"
+
+
+def _build_scoped_query(query: str = "", mail_scope: str = "inbox") -> str:
+    """Build a Gmail search query for the selected mail scope."""
+    query = (query or "").strip()
+    if mail_scope == "all":
+        return query
+    if not query:
+        return "in:inbox"
+    return f"in:inbox {query}"
+
+
+def _list_params_for_scope(mail_scope: str) -> dict:
+    return {"labelIds": ["INBOX"]} if mail_scope == "inbox" else {}
+
+
 def scan_senders_for_delete(limit: int = 1000, filters: Optional[dict] = None):
     """Scan emails and group by sender for bulk delete."""
     # Validate input
@@ -38,12 +58,19 @@ def scan_senders_for_delete(limit: int = 1000, filters: Optional[dict] = None):
     try:
         state.delete_scan_status["message"] = "Fetching emails..."
 
-        query = build_gmail_query(filters)
+        mail_scope = _get_mail_scope(filters)
+        query = _build_scoped_query(build_gmail_query(filters), mail_scope)
+        scope_params = _list_params_for_scope(mail_scope)
 
         results = (
             service.users()
             .messages()
-            .list(userId="me", maxResults=min(limit, 500), q=query or None)
+            .list(
+                userId="me",
+                maxResults=min(limit, 500),
+                q=query or None,
+                **scope_params,
+            )
             .execute()
         )
 
@@ -58,6 +85,7 @@ def scan_senders_for_delete(limit: int = 1000, filters: Optional[dict] = None):
                     maxResults=min(limit - len(messages), 500),
                     pageToken=results["nextPageToken"],
                     q=query or None,
+                    **scope_params,
                 )
                 .execute()
             )
@@ -87,15 +115,9 @@ def scan_senders_for_delete(limit: int = 1000, filters: Optional[dict] = None):
             }
         )
         processed = 0
-        batch_size = 100
+        batch_size = 25
 
-        def process_message(request_id, response, exception) -> None:
-            nonlocal processed
-            processed += 1
-
-            if exception:
-                return
-
+        def process_message_response(response) -> None:
             headers = response.get("payload", {}).get("headers", [])
             sender_name, sender_email = get_sender_info(headers)
             subject = get_subject(headers)
@@ -124,9 +146,47 @@ def scan_senders_for_delete(limit: int = 1000, filters: Optional[dict] = None):
                         sender_counts[sender_email]["first_date"] = email_date
                     sender_counts[sender_email]["last_date"] = email_date
 
+        def retry_message_get(msg_id: str) -> None:
+            nonlocal processed
+
+            for attempt in range(3):
+                try:
+                    if attempt > 0:
+                        time.sleep(0.5 * attempt)
+                    response = (
+                        service.users()
+                        .messages()
+                        .get(
+                            userId="me",
+                            id=msg_id,
+                            format="metadata",
+                            metadataHeaders=["From", "Subject", "Date"],
+                        )
+                        .execute()
+                    )
+                    process_message_response(response)
+                    processed += 1
+                    return
+                except Exception as e:
+                    if attempt == 2:
+                        logger.warning("Failed to fetch message %s: %s", msg_id, e)
+            processed += 1
+
         # Execute batch requests
         for i in range(0, len(messages), batch_size):
             batch_ids = messages[i : i + batch_size]
+            failed_ids = []
+
+            def process_message(request_id, response, exception) -> None:
+                nonlocal processed
+
+                if exception:
+                    failed_ids.append(request_id)
+                    return
+
+                process_message_response(response)
+                processed += 1
+
             batch = service.new_batch_http_request(callback=process_message)
 
             for msg_data in batch_ids:
@@ -139,9 +199,14 @@ def scan_senders_for_delete(limit: int = 1000, filters: Optional[dict] = None):
                         format="metadata",
                         metadataHeaders=["From", "Subject", "Date"],
                     )
+                    ,
+                    request_id=msg_data["id"],
                 )
 
             batch.execute()
+
+            for msg_id in failed_ids:
+                retry_message_get(msg_id)
 
             progress = int((i + len(batch_ids)) / total * 100)
             state.delete_scan_status["progress"] = progress
@@ -177,7 +242,7 @@ def get_delete_scan_results() -> list:
     return state.delete_scan_results.copy()
 
 
-def delete_emails_by_sender(sender: str) -> dict:
+def delete_emails_by_sender(sender: str, mail_scope: str = "inbox") -> dict:
     """Delete all emails from a specific sender."""
     if not sender or not sender.strip():
         return {
@@ -215,11 +280,13 @@ def delete_emails_by_sender(sender: str) -> dict:
 
     try:
         # Find all emails from sender
-        query = f"from:{sender}"
+        mail_scope = "all" if mail_scope == "all" else "inbox"
+        query = _build_scoped_query(f"from:{sender}", mail_scope)
+        scope_params = _list_params_for_scope(mail_scope)
         results = (
             service.users()
             .messages()
-            .list(userId="me", q=query, maxResults=500)
+            .list(userId="me", q=query or None, maxResults=500, **scope_params)
             .execute()
         )
         messages = results.get("messages", [])
@@ -233,6 +300,7 @@ def delete_emails_by_sender(sender: str) -> dict:
                     q=query,
                     maxResults=500,
                     pageToken=results["nextPageToken"],
+                    **scope_params,
                 )
                 .execute()
             )
@@ -274,7 +342,7 @@ def delete_emails_by_sender(sender: str) -> dict:
         return {"success": False, "deleted": 0, "size_freed": 0, "message": str(e)}
 
 
-def delete_emails_bulk(senders: list[str]) -> dict:
+def delete_emails_bulk(senders: list[str], mail_scope: str = "inbox") -> dict:
     """Delete emails from multiple senders."""
     if not senders:
         return {
@@ -289,7 +357,7 @@ def delete_emails_bulk(senders: list[str]) -> dict:
     errors = []
 
     for sender in senders:
-        result = delete_emails_by_sender(sender)
+        result = delete_emails_by_sender(sender, mail_scope)
         if result["success"]:
             total_deleted += result["deleted"]
             total_size_freed += result.get("size_freed", 0)
@@ -321,7 +389,7 @@ def delete_emails_bulk(senders: list[str]) -> dict:
     }
 
 
-def delete_emails_bulk_background(senders: list[str]) -> None:
+def delete_emails_bulk_background(senders: list[str], mail_scope: str = "inbox") -> None:
     """Delete emails from multiple senders with progress updates (background task).
 
     Optimized to collect all message IDs first, then batch delete in larger chunks.
@@ -347,6 +415,8 @@ def delete_emails_bulk_background(senders: list[str]) -> None:
     # Phase 1: Collect all message IDs from all senders
     all_message_ids = []
     errors = []
+    mail_scope = "all" if mail_scope == "all" else "inbox"
+    scope_params = _list_params_for_scope(mail_scope)
 
     for i, sender in enumerate(senders):
         state.delete_bulk_status["current_sender"] = i + 1
@@ -356,11 +426,11 @@ def delete_emails_bulk_background(senders: list[str]) -> None:
         state.delete_bulk_status["message"] = f"Finding emails from {sender}..."
 
         try:
-            query = f"from:{sender}"
+            query = _build_scoped_query(f"from:{sender}", mail_scope)
             results = (
                 service.users()
                 .messages()
-                .list(userId="me", q=query, maxResults=500)
+                .list(userId="me", q=query or None, maxResults=500, **scope_params)
                 .execute()
             )
             messages = results.get("messages", [])
@@ -374,6 +444,7 @@ def delete_emails_bulk_background(senders: list[str]) -> None:
                         q=query,
                         maxResults=500,
                         pageToken=results["nextPageToken"],
+                        **scope_params,
                     )
                     .execute()
                 )

--- a/static/css/filters.css
+++ b/static/css/filters.css
@@ -38,6 +38,46 @@
     color: var(--text-secondary);
 }
 
+.filter-scope-group {
+    gap: 0;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+    background: var(--card-bg);
+}
+
+.filter-radio {
+    position: relative;
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    color: var(--text-secondary);
+}
+
+.filter-radio input {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.filter-radio span {
+    display: block;
+    min-width: 54px;
+    padding: 6px 12px;
+    text-align: center;
+    font-size: 13px;
+    line-height: 1.2;
+}
+
+.filter-radio + .filter-radio {
+    border-left: 1px solid var(--border-color);
+}
+
+.filter-radio input:checked + span {
+    background: var(--primary-color);
+    color: white;
+}
+
 .filter-select {
     padding: 6px 12px;
     border: 1px solid var(--border-color);

--- a/static/js/delete.js
+++ b/static/js/delete.js
@@ -68,6 +68,7 @@ GmailCleaner.Delete = {
 
         const limit = document.getElementById('deleteScanLimit').value;
         const filters = GmailCleaner.Filters.get();
+        GmailCleaner.deleteMailScope = filters.mail_scope || 'inbox';
 
         try {
             const response = await fetch('/api/delete-scan', {
@@ -226,7 +227,10 @@ GmailCleaner.Delete = {
             const response = await fetch('/api/delete-emails', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ sender: r.email })
+                body: JSON.stringify({
+                    sender: r.email,
+                    mail_scope: GmailCleaner.deleteMailScope || 'inbox'
+                })
             });
             const result = await response.json();
 
@@ -296,7 +300,10 @@ GmailCleaner.Delete = {
             await fetch('/api/delete-emails-bulk', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ senders: senderEmails })
+                body: JSON.stringify({
+                    senders: senderEmails,
+                    mail_scope: GmailCleaner.deleteMailScope || 'inbox'
+                })
             });
 
             // Poll for progress

--- a/static/js/filters.js
+++ b/static/js/filters.js
@@ -134,6 +134,7 @@ GmailCleaner.Filters = {
         const category = document.getElementById('filterCategory')?.value || '';
         const sender = document.getElementById('filterSender')?.value?.trim() || '';
         const label = document.getElementById('filterLabel')?.value || '';
+        const mailScope = document.querySelector('input[name="mailScope"]:checked')?.value || 'inbox';
 
         return {
             older_than: olderThan,
@@ -142,7 +143,8 @@ GmailCleaner.Filters = {
             larger_than: largerThan,
             category: category,
             sender: sender,
-            label: label
+            label: label,
+            mail_scope: mailScope
         };
     },
 
@@ -153,12 +155,14 @@ GmailCleaner.Filters = {
         const sender = document.getElementById('filterSender');
         const label = document.getElementById('filterLabel');
         const dateRangeGroup = document.getElementById('dateRangeGroup');
+        const inboxScope = document.querySelector('input[name="mailScope"][value="inbox"]');
 
         if (olderThan) olderThan.value = '';
         if (largerThan) largerThan.value = '';
         if (category) category.value = '';
         if (sender) sender.value = '';
         if (label) label.value = '';
+        if (inboxScope) inboxScope.checked = true;
 
         // Clear date picker
         if (this.litepicker) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -93,6 +93,16 @@
                             </svg>
                             Filters:
                         </span>
+                        <div class="filter-group filter-scope-group" role="radiogroup" aria-label="Mail scope">
+                            <label class="filter-radio">
+                                <input type="radio" name="mailScope" value="inbox" checked>
+                                <span>Inbox</span>
+                            </label>
+                            <label class="filter-radio">
+                                <input type="radio" name="mailScope" value="all">
+                                <span>All</span>
+                            </label>
+                        </div>
                         <div class="filter-group">
                             <label for="filterOlderThan">Older than</label>
                             <select id="filterOlderThan" class="filter-select">

--- a/tests/unit/api/test_api_actions.py
+++ b/tests/unit/api/test_api_actions.py
@@ -160,7 +160,7 @@ class TestDeleteEmailsEndpoint:
             "/api/delete-emails", json={"sender": "newsletter@example.com"}
         )
         assert response.status_code == 200
-        mock_delete.assert_called_once_with("newsletter@example.com")
+        mock_delete.assert_called_once_with("newsletter@example.com", "inbox")
 
 
 class TestDeleteBulkEndpoint:
@@ -173,7 +173,7 @@ class TestDeleteBulkEndpoint:
         response = client.post("/api/delete-emails-bulk", json={"senders": senders})
         assert response.status_code == 200
         assert response.json() == {"status": "started"}
-        mock_delete.assert_called_once_with(senders)
+        mock_delete.assert_called_once_with(senders, "inbox")
 
     def test_delete_bulk_large_senders_list(self, client):
         """POST /api/delete-emails-bulk with many senders should succeed (no limit)."""
@@ -188,7 +188,7 @@ class TestDeleteBulkEndpoint:
         response = client.post("/api/delete-emails-bulk", json={"senders": []})
         assert response.status_code == 200
         assert response.json() == {"status": "started"}
-        mock_delete.assert_called_once_with([])
+        mock_delete.assert_called_once_with([], "inbox")
 
 
 class TestRequestValidation:

--- a/tests/unit/services/gmail/test_delete_service.py
+++ b/tests/unit/services/gmail/test_delete_service.py
@@ -1,0 +1,219 @@
+"""
+Tests for Gmail delete operations.
+"""
+
+from app.core import state
+from app.services.gmail import delete as delete_service
+
+
+class FakeRequest:
+    def __init__(self, response):
+        self.response = response
+
+    def execute(self):
+        return self.response
+
+
+class RecordingMessages:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.list_calls = []
+
+    def list(self, **kwargs):
+        self.list_calls.append(kwargs)
+        response = self.responses.pop(0) if self.responses else {"messages": []}
+        return FakeRequest(response)
+
+
+class RecordingUsers:
+    def __init__(self, messages):
+        self._messages = messages
+
+    def messages(self):
+        return self._messages
+
+
+class RecordingService:
+    def __init__(self, responses):
+        self.messages_api = RecordingMessages(responses)
+        self.users_api = RecordingUsers(self.messages_api)
+
+    def users(self):
+        return self.users_api
+
+
+class BatchRetryMessages:
+    def __init__(self):
+        self.list_calls = []
+        self.get_calls = []
+        self.responses = {
+            "ok": {
+                "id": "ok",
+                "payload": {
+                    "headers": [
+                        {"name": "From", "value": "Pleo <no-reply@info.pleo.io>"},
+                        {"name": "Subject", "value": "First"},
+                    ]
+                },
+            },
+            "retry": {
+                "id": "retry",
+                "payload": {
+                    "headers": [
+                        {"name": "From", "value": "Pleo <no-reply@info.pleo.io>"},
+                        {"name": "Subject", "value": "Second"},
+                    ]
+                },
+            },
+        }
+
+    def list(self, **kwargs):
+        self.list_calls.append(kwargs)
+        return FakeRequest({"messages": [{"id": "ok"}, {"id": "retry"}]})
+
+    def get(self, **kwargs):
+        self.get_calls.append(kwargs)
+        return FakeRequest(self.responses[kwargs["id"]])
+
+
+class BatchRetryBatch:
+    def __init__(self, callback, messages):
+        self.callback = callback
+        self.messages = messages
+        self.requests = []
+
+    def add(self, request, request_id=None):
+        self.requests.append((request, request_id))
+
+    def execute(self):
+        for request, request_id in self.requests:
+            if request_id == "retry":
+                self.callback(request_id, None, Exception("rate limit"))
+            else:
+                self.callback(request_id, self.messages.responses[request_id], None)
+
+
+class BatchRetryService:
+    def __init__(self):
+        self.messages_api = BatchRetryMessages()
+        self.users_api = RecordingUsers(self.messages_api)
+
+    def users(self):
+        return self.users_api
+
+    def new_batch_http_request(self, callback):
+        return BatchRetryBatch(callback, self.messages_api)
+
+
+def test_delete_scan_lists_inbox_only(monkeypatch):
+    service = RecordingService([{"messages": []}])
+    monkeypatch.setattr(delete_service, "get_gmail_service", lambda: (service, None))
+
+    delete_service.scan_senders_for_delete(limit=1000)
+
+    assert service.messages_api.list_calls == [
+        {
+            "userId": "me",
+            "maxResults": 500,
+            "q": "in:inbox",
+            "labelIds": ["INBOX"],
+        }
+    ]
+    assert state.delete_scan_status["done"] is True
+
+
+def test_delete_scan_combines_filters_with_inbox(monkeypatch):
+    service = RecordingService([{"messages": []}])
+    monkeypatch.setattr(delete_service, "get_gmail_service", lambda: (service, None))
+
+    delete_service.scan_senders_for_delete(
+        limit=1000, filters={"sender": "no-reply@info.pleo.io"}
+    )
+
+    assert service.messages_api.list_calls[0]["q"] == (
+        "in:inbox from:no-reply@info.pleo.io"
+    )
+    assert service.messages_api.list_calls[0]["labelIds"] == ["INBOX"]
+
+
+def test_delete_scan_can_include_all_mail(monkeypatch):
+    service = RecordingService([{"messages": []}])
+    monkeypatch.setattr(delete_service, "get_gmail_service", lambda: (service, None))
+
+    delete_service.scan_senders_for_delete(
+        limit=1000,
+        filters={"sender": "no-reply@info.pleo.io", "mail_scope": "all"},
+    )
+
+    assert service.messages_api.list_calls == [
+        {
+            "userId": "me",
+            "maxResults": 500,
+            "q": "from:no-reply@info.pleo.io",
+        }
+    ]
+
+
+def test_delete_by_sender_searches_inbox_only(monkeypatch):
+    service = RecordingService([{"messages": []}])
+    monkeypatch.setattr(delete_service, "get_gmail_service", lambda: (service, None))
+
+    result = delete_service.delete_emails_by_sender("no-reply@info.pleo.io")
+
+    assert result["success"] is True
+    assert service.messages_api.list_calls == [
+        {
+            "userId": "me",
+            "q": "in:inbox from:no-reply@info.pleo.io",
+            "maxResults": 500,
+            "labelIds": ["INBOX"],
+        }
+    ]
+
+
+def test_delete_by_sender_can_include_all_mail(monkeypatch):
+    service = RecordingService([{"messages": []}])
+    monkeypatch.setattr(delete_service, "get_gmail_service", lambda: (service, None))
+
+    result = delete_service.delete_emails_by_sender(
+        "no-reply@info.pleo.io", mail_scope="all"
+    )
+
+    assert result["success"] is True
+    assert service.messages_api.list_calls == [
+        {
+            "userId": "me",
+            "q": "from:no-reply@info.pleo.io",
+            "maxResults": 500,
+        }
+    ]
+
+
+def test_bulk_delete_collects_inbox_only(monkeypatch):
+    service = RecordingService([{"messages": []}])
+    monkeypatch.setattr(delete_service, "get_gmail_service", lambda: (service, None))
+
+    delete_service.delete_emails_bulk_background(["no-reply@info.pleo.io"])
+
+    assert service.messages_api.list_calls == [
+        {
+            "userId": "me",
+            "q": "in:inbox from:no-reply@info.pleo.io",
+            "maxResults": 500,
+            "labelIds": ["INBOX"],
+        }
+    ]
+    assert state.delete_bulk_status["done"] is True
+
+
+def test_delete_scan_retries_failed_batch_metadata_fetch(monkeypatch):
+    service = BatchRetryService()
+    monkeypatch.setattr(delete_service, "get_gmail_service", lambda: (service, None))
+
+    delete_service.scan_senders_for_delete(limit=1000)
+
+    results = delete_service.get_delete_scan_results()
+    assert results[0]["email"] == "no-reply@info.pleo.io"
+    assert results[0]["count"] == 2
+    assert results[0]["message_ids"] == ["ok", "retry"]
+    assert service.messages_api.get_calls[-1]["id"] == "retry"


### PR DESCRIPTION
## Description

When using gmail-cleaner's "Delete Emails" feature I realised that the tool was scanning ALL of my emails, not only those in my Gmail "inbox". This felt wrong to me as I was using the tool to Delete or Archive email and get them out of my inbox. But after Archive/Delete actions were completed, those emails could still appear in the scan, so it felt like I was seeing the same archived emails again and again.

I have added an inbox-only filter to make my experience better, but in doing so I found bugs with 429 errors from the Google API not being handled and the API being used more than necessary. When rebuilding the container, sometimes I had to hard-refresh to get new JS changes loaded - this again felt wrong and therefore I added asset hashing to auto-update broser caches.

Changes include:

- This PR fixes delete-scan accuracy and scope handling for Gmail cleanup.
- Makes Delete Emails scan inbox-only by default using in:inbox and labelIds=["INBOX"]
- Adds an Inbox / All mail-scope selector to the filter bar
- Threads mail_scope through delete scan, single delete, and bulk delete actions
- Retries failed Gmail metadata batch fetches to avoid silently dropping messages when Gmail returns 429 Too many concurrent requests
- Reduces delete scan metadata batch size to lower rate-limit pressure
- Adds frontend asset content hashing so Docker rebuilds force browsers to load updated JS/CSS instead of stale v=1.0.0 assets
- Adds regression coverage for inbox/all scope behavior and retrying failed batch metadata fetches

## Checklist

- [x] uv run pytest tests/unit
- [x] Verified live delete scan results against Gmail API for pleo.io:Inbox scope returns expected inbox senders/counts
All scope is accepted and does not force INBOX filtering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

- **Mail Scope Selection**: Added inbox/all mail scope selector to the filter bar UI with `mail_scope` field across `FiltersModel`, `DeleteEmailsRequest`, and `DeleteBulkRequest` schemas; defaults to inbox to limit scans to user's inbox only
- **Mail Scope Propagation**: Extended `delete_emails_by_sender()`, `delete_emails_bulk()`, and `delete_emails_bulk_background()` functions to accept and use `mail_scope` parameter throughout the delete scan and deletion flows
- **Inbox Query Integration**: Implemented mail scope helpers in delete service to map scope selection to Gmail search queries (`in:inbox` filter) and label filters (`labelIds=["INBOX"]`) for consistent filtering across operations
- **Batch Fetch Retry Logic**: Added callback-based batch metadata processing with per-message retry handling for failed requests, addressing 429 rate-limit errors that previously caused messages to be silently dropped; reduced batch size to lower rate-limit pressure
- **Asset-Based Cache Busting**: Implemented `get_asset_hash()` helper to compute content hashes from frontend assets in `static/` and `templates/`, enabling automatic browser cache updates when container rebuilds occur without manual hard-refreshes
- **Frontend Integration**: Updated `GmailCleaner.Delete` and `GmailCleaner.Filters` JavaScript to capture and pass `mail_scope` in delete request payloads; added UI controls and state management for mail scope selection
- **Test Coverage**: Added 7 unit tests validating inbox/all scope behavior, filter combination, batch fetch retry logic, and bulk deletion operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->