### PR TITLE
feat: add OAUTH_REDIRECT_URI to support HTTPS reverse proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ If you're accessing via a **custom domain** (e.g., `gmail.example.com`) instead 
 - ✅ `http://localhost:8767/` (for local access)
 - ✅ `http://gmail.example.com:8767/` (custom domain)
 - ✅ `http://mygmail.duckdns.org:8767/` (dynamic DNS)
+- ✅ `https://gmail.example.com/` (HTTPS reverse proxy — requires [`OAUTH_REDIRECT_URI`](#3-for-https-with-reverse-proxy))
 - ❌ `http://192.168.1.100:8767/` (IP addresses not allowed)
 - ❌ `http://10.0.0.5:8767/` (private IPs not allowed)
 
@@ -306,10 +307,35 @@ If you're accessing via a **custom domain** (e.g., `gmail.example.com`) instead 
    > - Use a domain name, NOT an IP address (e.g., ~~`192.168.1.100`~~)
 
 3. **For HTTPS with reverse proxy**:
+
+   Set `OAUTH_REDIRECT_URI` to the exact URL your proxy serves. It is used verbatim, so you
+   can keep `https` and drop the port. `OAUTH_HOST` and `OAUTH_EXTERNAL_PORT` are ignored
+   when it is set:
+
+   ```yaml
+   environment:
+     - WEB_AUTH=true
+     - OAUTH_REDIRECT_URI=https://gmail.example.com/
+   ```
+
+   - Register that same URL, character for character, as the **Authorized redirect URI** in Google Cloud
+   - Point your proxy at container port **8767** for that URL — it serves the OAuth callback
+   - Proxy port 8766 (web UI) as usual
+
+   > **Why this setting exists**: without it the callback URL is always built as
+   > `http://HOST:PORT/`. That URL is sent to Google twice — once to start authorization, and
+   > again to exchange the code for a token — so editing it by hand in the browser only moves
+   > the failure to the token exchange, which fails with `redirect_uri_mismatch`.
+
+   <details>
+   <summary>Without <code>OAUTH_REDIRECT_URI</code> (plain HTTP passthrough)</summary>
+
    - The OAuth callback uses HTTP on port 8767 internally
    - Your reverse proxy should forward port 8767 for the OAuth callback
    - The **Authorized redirect URI** in Google Cloud must be `http://YOUR_DOMAIN:8767/` (HTTP, not HTTPS) or use the external port if mapped
    - Proxy both port 8766 (app) and port 8767 (OAuth callback) through your reverse proxy
+
+   </details>
 
 ## Troubleshooting
 
@@ -338,6 +364,24 @@ Your app is missing test users in the OAuth setup:
 This is normal for personal OAuth apps! Click **Continue** to proceed.
 
 This warning appears because your app isn't published to Google - which is exactly what we want for privacy!
+
+#### "OAuth error: Redirect URI mismatch" behind an HTTPS reverse proxy
+
+If the URL in the logs is `http://YOUR_DOMAIN:8767/` but your proxy serves the app over
+HTTPS on port 443, set the callback URL explicitly instead of editing it in the browser:
+
+```yaml
+environment:
+  - OAUTH_REDIRECT_URI=https://gmail.example.com/
+```
+
+Then register exactly that URL under **Authorized redirect URIs** in Google Cloud, and make
+sure your proxy forwards it to container port 8767.
+
+> **Why editing the URL by hand doesn't work**: the callback URL is sent to Google twice —
+> once to start authorization and again to exchange the code for a token. Changing it only
+> in the browser leaves the app exchanging the code against the original URL, so Google
+> rejects the second call with `redirect_uri_mismatch`.
 
 #### OAuth CSRF Error / State Mismatch
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ If you're accessing via a **custom domain** (e.g., `gmail.example.com`) instead 
 - ✅ `http://localhost:8767/` (for local access)
 - ✅ `http://gmail.example.com:8767/` (custom domain)
 - ✅ `http://mygmail.duckdns.org:8767/` (dynamic DNS)
-- ✅ `https://gmail.example.com/` (HTTPS reverse proxy — requires [`OAUTH_REDIRECT_URI`](#3-for-https-with-reverse-proxy))
+- ✅ `https://gmail.example.com/` (HTTPS reverse proxy — requires [`OAUTH_REDIRECT_URI`](#oauth-error-redirect-uri-mismatch-behind-an-https-reverse-proxy))
 - ❌ `http://192.168.1.100:8767/` (IP addresses not allowed)
 - ❌ `http://10.0.0.5:8767/` (private IPs not allowed)
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -58,7 +58,9 @@ class Settings(BaseSettings):
                 f"Invalid OAUTH_REDIRECT_URI: {v!r}. "
                 "Must be an absolute URL starting with http:// or https://."
             )
-        if not parsed.netloc:
+        # Check hostname, not netloc: "https://:443/" and "https://user@/" both
+        # have a non-empty netloc but no host at all, and Google rejects them.
+        if not parsed.hostname:
             raise ValueError(
                 f"Invalid OAUTH_REDIRECT_URI: {v!r}. Must include a host, "
                 "e.g. https://gmail.example.com/."

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -5,6 +5,7 @@ Central configuration and settings for the application.
 """
 
 import os
+from urllib.parse import urlparse
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -32,6 +33,37 @@ class Settings(BaseSettings):
         default="localhost",
         description="Custom host for OAuth redirect (e.g., your domain or IP)",
     )
+    oauth_redirect_uri: str | None = Field(
+        default=None,
+        description=(
+            "Full OAuth redirect URI, e.g. https://gmail.example.com/. Set this when a "
+            "reverse proxy terminates TLS or serves the callback on a path/port that "
+            "cannot be expressed with oauth_host and oauth_external_port. "
+            "Takes precedence over both."
+        ),
+    )
+
+    @field_validator("oauth_redirect_uri", mode="before")
+    @classmethod
+    def validate_oauth_redirect_uri(cls, v) -> str | None:
+        """Reject redirect URIs Google would refuse, so it fails at startup not mid-flow."""
+        if v is None:
+            return None
+        if not isinstance(v, str) or not v.strip():
+            return None
+        v = v.strip()
+        parsed = urlparse(v)
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError(
+                f"Invalid OAUTH_REDIRECT_URI: {v!r}. "
+                "Must be an absolute URL starting with http:// or https://."
+            )
+        if not parsed.netloc:
+            raise ValueError(
+                f"Invalid OAUTH_REDIRECT_URI: {v!r}. Must include a host, "
+                "e.g. https://gmail.example.com/."
+            )
+        return v
 
     @field_validator("web_auth", mode="before")
     @classmethod

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -298,6 +298,16 @@ def get_gmail_service():
                         else settings.oauth_port
                     )
 
+                    # An explicit redirect URI wins over host/port composition. This is the
+                    # only way to express a scheme other than http, or a URI with no port at
+                    # all - both of which a TLS-terminating reverse proxy needs.
+                    configured_redirect_uri = (
+                        settings.oauth_redirect_uri.strip()
+                        if isinstance(settings.oauth_redirect_uri, str)
+                        and settings.oauth_redirect_uri.strip()
+                        else None
+                    )
+
                     # Validate port ranges (1-65535)
                     if not isinstance(settings.oauth_port, int) or not (
                         1 <= settings.oauth_port <= 65535
@@ -328,23 +338,38 @@ def get_gmail_service():
                             shutil.which("xdg-open") or os.environ.get("DISPLAY")
                         )
 
-                    # If external port is different, manually handle OAuth flow
-                    # because run_local_server() constructs redirect URI from port parameter
-                    if redirect_port != settings.oauth_port:
-                        # Validate oauth_host is not empty
-                        if not settings.oauth_host or not settings.oauth_host.strip():
-                            raise ValueError(
-                                "oauth_host cannot be empty when using custom external port. "
-                                "Please set OAUTH_HOST environment variable."
+                    # Drive the OAuth flow by hand whenever the redirect URI is not what
+                    # run_local_server() would build, since it always derives
+                    # "http://{host}:{port}/" from its own arguments - and uses that same
+                    # value again at token exchange, where a mismatch is fatal.
+                    if configured_redirect_uri or redirect_port != settings.oauth_port:
+                        if configured_redirect_uri:
+                            redirect_uri = configured_redirect_uri
+                            logger.info(
+                                f"Using configured redirect URI {redirect_uri} "
+                                f"(callback server listening on internal port {settings.oauth_port})"
+                            )
+                        else:
+                            # Validate oauth_host is not empty
+                            if (
+                                not settings.oauth_host
+                                or not settings.oauth_host.strip()
+                            ):
+                                raise ValueError(
+                                    "oauth_host cannot be empty when using custom external port. "
+                                    "Please set OAUTH_HOST environment variable."
+                                )
+
+                            # Construct redirect URI using external port
+                            redirect_uri = (
+                                f"http://{settings.oauth_host}:{redirect_port}/"
+                            )
+                            logger.info(
+                                f"Using custom redirect URI {redirect_uri} "
+                                f"(internal port: {settings.oauth_port}, external port: {redirect_port})"
                             )
 
-                        # Construct redirect URI using external port
-                        redirect_uri = f"http://{settings.oauth_host}:{redirect_port}/"
                         flow.redirect_uri = redirect_uri
-                        logger.info(
-                            f"Using custom redirect URI {redirect_uri} "
-                            f"(internal port: {settings.oauth_port}, external port: {redirect_port})"
-                        )
 
                         # Manually handle OAuth flow with custom redirect URI
                         authorization_url, oauth_state = flow.authorization_url(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,4 +34,10 @@ services:
       # Uncomment and set OAUTH_EXTERNAL_PORT if using custom port mapping
       # (e.g., if you map ports like "18767:8767", set OAUTH_EXTERNAL_PORT=18767)
       # - OAUTH_EXTERNAL_PORT=18767
+
+      # Uncomment and set OAUTH_REDIRECT_URI if a reverse proxy terminates TLS.
+      # Used verbatim, so https and a portless URL both work, and it overrides the
+      # two settings above. Must match the Authorized redirect URI in Google Cloud
+      # character for character, and must be proxied to container port 8767.
+      # - OAUTH_REDIRECT_URI=https://gmail.example.com/
     restart: unless-stopped

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -1,0 +1,62 @@
+"""
+Tests for Application Settings
+------------------------------
+Validation of environment-driven configuration.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from app.core.config import Settings
+
+
+class TestOAuthRedirectUri:
+    """Tests for the OAUTH_REDIRECT_URI setting."""
+
+    def test_defaults_to_none(self):
+        """Unset OAUTH_REDIRECT_URI leaves host/port composition in charge."""
+        assert Settings(_env_file=None).oauth_redirect_uri is None
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "https://gmail.example.com/",
+            "https://gmail.example.com/oauth2/callback",
+            "http://localhost:8767/",
+        ],
+    )
+    def test_accepts_absolute_http_urls(self, value):
+        """Any absolute http(s) URL is a legal redirect URI."""
+        assert (
+            Settings(_env_file=None, oauth_redirect_uri=value).oauth_redirect_uri
+            == value
+        )
+
+    def test_strips_surrounding_whitespace(self):
+        """Whitespace from an env file or compose block must not reach Google."""
+        settings = Settings(
+            _env_file=None, oauth_redirect_uri="  https://gmail.example.com/  "
+        )
+        assert settings.oauth_redirect_uri == "https://gmail.example.com/"
+
+    @pytest.mark.parametrize("value", ["", "   "])
+    def test_blank_is_treated_as_unset(self, value):
+        """An empty override should fall back rather than produce an invalid URI."""
+        assert (
+            Settings(_env_file=None, oauth_redirect_uri=value).oauth_redirect_uri
+            is None
+        )
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "gmail.example.com",  # no scheme
+            "gmail.example.com:8767/",  # host:port parsed as scheme
+            "ftp://gmail.example.com/",  # wrong scheme
+            "https://",  # no host
+        ],
+    )
+    def test_rejects_uris_google_would_refuse(self, value):
+        """Fail at startup instead of surfacing redirect_uri_mismatch mid-flow."""
+        with pytest.raises(ValidationError):
+            Settings(_env_file=None, oauth_redirect_uri=value)

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -54,6 +54,8 @@ class TestOAuthRedirectUri:
             "gmail.example.com:8767/",  # host:port parsed as scheme
             "ftp://gmail.example.com/",  # wrong scheme
             "https://",  # no host
+            "https://:443/",  # port only - netloc is truthy, host is not
+            "https://user@/",  # userinfo only - netloc is truthy, host is not
         ],
     )
     def test_rejects_uris_google_would_refuse(self, value):

--- a/tests/unit/services/auth/test_oauth_flow_complete.py
+++ b/tests/unit/services/auth/test_oauth_flow_complete.py
@@ -4,6 +4,7 @@ Tests for Complete OAuth Flow Scenarios
 Tests for successful OAuth flows and edge cases not covered in existing tests.
 """
 
+import threading
 from unittest.mock import Mock, patch, mock_open
 
 
@@ -336,3 +337,154 @@ class TestOAuthFlowErrors:
         # Note: This tests the structure, actual reset happens in background thread
         assert service is None
         assert error is not None
+
+
+class TestConfiguredRedirectUri:
+    """Tests for the OAUTH_REDIRECT_URI override (reverse proxy / TLS termination)."""
+
+    @staticmethod
+    def _abort_after_redirect_uri(mock_flow_instance):
+        """Stop the flow right after redirect_uri is set, and signal when that happened.
+
+        run_oauth() always runs on a background thread, so the test needs a
+        happens-before edge rather than relying on it finishing in time.
+        """
+        reached = threading.Event()
+
+        def fake_authorization_url(**_kwargs):
+            reached.set()
+            # A falsy URL makes run_oauth raise ValueError and unwind cleanly,
+            # which is enough: redirect_uri is already assigned by this point.
+            return (None, None)
+
+        mock_flow_instance.authorization_url.side_effect = fake_authorization_url
+        return reached
+
+    @patch("app.services.auth.settings")
+    @patch("app.services.auth._is_file_empty", return_value=False)
+    @patch("app.services.auth.os.path.exists")
+    @patch("app.services.auth.InstalledAppFlow")
+    @patch("app.services.auth._auth_in_progress", {"active": False})
+    @patch("app.services.auth.is_web_auth_mode", return_value=True)
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data='{"web": {"client_id": "test", "client_secret": "secret"}}',
+    )
+    def test_configured_redirect_uri_is_used_verbatim(
+        self,
+        mock_file,
+        mock_web_auth,
+        mock_flow,
+        mock_exists,
+        mock_is_file_empty,
+        mock_settings,
+    ):
+        """OAUTH_REDIRECT_URI should be used as-is, keeping https and dropping the port."""
+        mock_settings.credentials_file = "credentials.json"
+        mock_settings.token_file = "token.json"
+        mock_settings.scopes = ["scope1", "scope2"]
+        mock_settings.oauth_port = 8767
+        mock_settings.oauth_external_port = None
+        mock_settings.oauth_host = "gmail.example.com"
+        mock_settings.oauth_redirect_uri = "https://gmail.example.com/"
+
+        mock_exists.side_effect = lambda path: "credentials.json" in str(path)
+
+        mock_flow_instance = Mock()
+        mock_flow.from_client_secrets_file.return_value = mock_flow_instance
+        reached = self._abort_after_redirect_uri(mock_flow_instance)
+
+        auth.get_gmail_service()
+
+        assert reached.wait(timeout=5), "OAuth flow never reached authorization_url"
+        assert mock_flow_instance.redirect_uri == "https://gmail.example.com/"
+        # run_local_server would rebuild the URI as http://host:port/ and break token exchange
+        mock_flow_instance.run_local_server.assert_not_called()
+
+    @patch("app.services.auth.settings")
+    @patch("app.services.auth._is_file_empty", return_value=False)
+    @patch("app.services.auth.os.path.exists")
+    @patch("app.services.auth.InstalledAppFlow")
+    @patch("app.services.auth._auth_in_progress", {"active": False})
+    @patch("app.services.auth.is_web_auth_mode", return_value=True)
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data='{"web": {"client_id": "test", "client_secret": "secret"}}',
+    )
+    def test_configured_redirect_uri_overrides_external_port(
+        self,
+        mock_file,
+        mock_web_auth,
+        mock_flow,
+        mock_exists,
+        mock_is_file_empty,
+        mock_settings,
+    ):
+        """OAUTH_REDIRECT_URI should win over OAUTH_EXTERNAL_PORT composition."""
+        mock_settings.credentials_file = "credentials.json"
+        mock_settings.token_file = "token.json"
+        mock_settings.scopes = ["scope1", "scope2"]
+        mock_settings.oauth_port = 8767
+        mock_settings.oauth_external_port = 18767
+        mock_settings.oauth_host = "gmail.example.com"
+        mock_settings.oauth_redirect_uri = "https://gmail.example.com/oauth2/callback"
+
+        mock_exists.side_effect = lambda path: "credentials.json" in str(path)
+
+        mock_flow_instance = Mock()
+        mock_flow.from_client_secrets_file.return_value = mock_flow_instance
+        reached = self._abort_after_redirect_uri(mock_flow_instance)
+
+        auth.get_gmail_service()
+
+        assert reached.wait(timeout=5), "OAuth flow never reached authorization_url"
+        assert (
+            mock_flow_instance.redirect_uri
+            == "https://gmail.example.com/oauth2/callback"
+        )
+
+    @patch("app.services.auth.settings")
+    @patch("app.services.auth._is_file_empty", return_value=False)
+    @patch("app.services.auth.os.path.exists")
+    @patch("app.services.auth.InstalledAppFlow")
+    @patch("app.services.auth._auth_in_progress", {"active": False})
+    @patch("app.services.auth.is_web_auth_mode", return_value=False)
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data='{"installed": {"client_id": "test", "client_secret": "secret"}}',
+    )
+    def test_unset_redirect_uri_keeps_run_local_server(
+        self,
+        mock_file,
+        mock_web_auth,
+        mock_flow,
+        mock_exists,
+        mock_is_file_empty,
+        mock_settings,
+    ):
+        """With OAUTH_REDIRECT_URI unset the original run_local_server path is kept."""
+        mock_settings.credentials_file = "credentials.json"
+        mock_settings.token_file = "token.json"
+        mock_settings.scopes = ["scope1", "scope2"]
+        mock_settings.oauth_port = 8767
+        mock_settings.oauth_external_port = None
+        mock_settings.oauth_host = "localhost"
+        mock_settings.oauth_redirect_uri = None
+
+        mock_exists.side_effect = lambda path: "credentials.json" in str(path)
+
+        mock_flow_instance = Mock()
+        mock_flow.from_client_secrets_file.return_value = mock_flow_instance
+
+        started = threading.Event()
+        mock_flow_instance.run_local_server.side_effect = (
+            lambda **_kwargs: started.set() or Mock()
+        )
+
+        auth.get_gmail_service()
+
+        assert started.wait(timeout=5), "run_local_server was never called"
+        mock_flow_instance.authorization_url.assert_not_called()


### PR DESCRIPTION
## Problem

The OAuth callback URL is always composed as `http://{host}:{port}/`, so a deployment behind a TLS-terminating reverse proxy has no way to express the URL it actually serves — e.g. `https://gmail.example.com/` on port 443. `OAUTH_HOST` cannot carry a scheme, and `OAUTH_EXTERNAL_PORT` cannot drop the port.

Editing the URL in the browser is not a workaround. The callback URL is sent to Google **twice** — once in the authorization request, and again in the token exchange — and `google-auth-oauthlib` reuses its own composed value for the second call. So authorization succeeds, then the token exchange fails, and the app reports:

```
OAuth error: Redirect URI mismatch. Please check your credentials.json redirect URI configuration.
```

This is confusing to debug, because the message points at `credentials.json` while the mismatch is actually between the app's two calls to Google.

The README currently documents the constraint as a requirement (["The **Authorized redirect URI** in Google Cloud must be `http://YOUR_DOMAIN:8767/` (HTTP, not HTTPS)"](https://github.com/Gururagavendra/gmail-cleaner/blob/main/README.md)), which forces plain HTTP for the callback even when the rest of the deployment is HTTPS.

Refs #95.

## Change

Adds `OAUTH_REDIRECT_URI`, used verbatim for **both** legs of the flow so the two always agree:

```yaml
environment:
  - WEB_AUTH=true
  - OAUTH_REDIRECT_URI=https://gmail.example.com/
```

- Takes precedence over `OAUTH_HOST` / `OAUTH_EXTERNAL_PORT`
- Validated at startup (scheme must be `http`/`https`, host required), so a malformed value fails immediately instead of surfacing as a `redirect_uri_mismatch` several steps later
- Blank/whitespace is treated as unset
- **Unset, behaviour is completely unchanged** — `run_local_server()` is still used when the redirect URI is what it would have built anyway

The existing manual-flow branch (added in #79 for `OAUTH_EXTERNAL_PORT`) already sets `flow.redirect_uri` and drives the callback server by hand, so this reuses that path rather than adding a new one.

## Docs

- README: new reverse-proxy instructions, plus a troubleshooting entry for the exact error message, both explaining *why* editing the URL by hand doesn't work. Previous HTTP-passthrough guidance kept in a `<details>` block.
- `docker-compose.yml`: commented example alongside the existing OAuth vars.

## Tests

`148 passed` (134 existing + 14 new), `ruff check` and `ruff format` clean, `bandit -ll -i` reports no medium/high findings.

New coverage:
- redirect URI used verbatim (https preserved, port dropped), and `run_local_server` not called
- overrides `OAUTH_EXTERNAL_PORT`
- unset → original `run_local_server` path retained
- validator: accepted forms, whitespace stripping, blank-as-unset, and rejection of schemeless / wrong-scheme / hostless values

I confirmed the two behavioural tests fail without the fix, with exactly the reported symptom:

```
E   AssertionError: assert 'http://gmail...le.com:18767/' == 'https://gmai...uth2/callback'
E     - https://gmail.example.com/oauth2/callback
E     + http://gmail.example.com:18767/
```

## Verification

Running behind Traefik terminating TLS on 443 and forwarding to container port 8767, with `https://<host>/` registered as the Authorized redirect URI in Google Cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Adds `OAUTH_REDIRECT_URI` support for HTTPS reverse-proxy deployments.
- Uses the configured URI verbatim for OAuth authorization and token exchange.
- Gives `OAUTH_REDIRECT_URI` precedence over `OAUTH_HOST` and `OAUTH_EXTERNAL_PORT`.
- Validates HTTP(S) URIs at startup, including required hostnames, and treats blank values as unset.
- Preserves the existing local-server flow when no URI override is configured.
- Updates README and Docker Compose documentation with reverse-proxy configuration and troubleshooting guidance.
- Adds tests for URI validation, precedence, fallback behavior, and URI handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->