### PR TITLE
feat(auth): show the OAuth authorization URL in the web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,17 @@ http://localhost:8766
    URL is ready. It also tries to open it in a new tab automatically - if your
    browser blocks the popup, just click the button.
 
-   Signing in from a different machine than the one running the browser? Click
+   Browsing from a different machine than the one running the container? Click
    **"Signing in on another device?"** to reveal the raw URL and copy it.
+
+   > **This only completes the sign-in if `OAUTH_HOST` names a host that the
+   > other machine can actually reach**, with the callback port reachable there
+   > too. With the default `OAUTH_HOST=localhost`, Google sends the browser back
+   > to `http://localhost:8767/` - which on any other machine is *that* machine,
+   > so the container never receives the authorization code. Consent will appear
+   > to succeed and the sign-in will silently not finish. Either set `OAUTH_HOST`
+   > to a resolvable domain (see [Advanced Configuration](#advanced-configuration))
+   > or complete the sign-in from the machine running the container.
 
 5. Authorize in the Google consent screen:
    - Choose your Google account

--- a/README.md
+++ b/README.md
@@ -145,21 +145,24 @@ http://localhost:8766
 
 3. Click **"Sign In"** button in the web UI
 
-4. Check logs for the OAuth URL (only after clicking Sign In!):
-```bash
-docker logs $(docker ps -q --filter ancestor=ghcr.io/gururagavendra/gmail-cleaner)
-```
-Or if you built locally:
-```bash
-docker logs $(docker ps -q --filter name=gmail-cleaner)
-```
+4. The app shows a **"Continue to Google"** button as soon as the authorization
+   URL is ready. It also tries to open it in a new tab automatically - if your
+   browser blocks the popup, just click the button.
 
-5. Copy the Google OAuth URL from logs, open in browser, and authorize:
+   Signing in from a different machine than the one running the browser? Click
+   **"Signing in on another device?"** to reveal the raw URL and copy it.
+
+5. Authorize in the Google consent screen:
    - Choose your Google account
    - "Google hasn't verified this app" → Click **Continue**
      > This warning appears because you created your own OAuth app (not published to Google). This is expected and safe - you control the app!
    - Grant permissions → Click **Continue**
    - Done! You'll see "Authentication flow has completed"
+
+> The authorization URL is still printed to the container logs as a fallback:
+> ```bash
+> docker logs $(docker ps -q --filter name=gmail-cleaner)
+> ```
 
 > **🌐 Using a custom domain, remote server, or custom port mapping?** See [Advanced Configuration](#advanced-configuration) for setup instructions.
 

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -29,6 +29,39 @@ logger = logging.getLogger(__name__)
 _auth_in_progress = {"active": False}
 
 
+def _publish_authorization_url(flow) -> None:
+    """Publish the consent URL that ``flow.run_local_server()`` builds internally.
+
+    ``run_local_server()`` constructs the authorization URL itself and only
+    prints it, so the URL is unreachable from the web UI. It builds that URL by
+    calling the public :meth:`Flow.authorization_url`, so wrapping that method
+    lets us record the URL in :data:`state.pending_auth_url` without
+    reimplementing the flow.
+
+    If a future version of ``google-auth-oauthlib`` stops routing through
+    :meth:`authorization_url`, nothing breaks: the URL simply stays ``None`` and
+    the behaviour falls back to today's log-only output.
+
+    Args:
+        flow: The OAuth flow whose authorization URL should be published.
+    """
+    original_authorization_url = flow.authorization_url
+
+    def capture_authorization_url(*args, **kwargs):
+        result = original_authorization_url(*args, **kwargs)
+        try:
+            state.pending_auth_url["url"] = result[0]
+        except (TypeError, IndexError, KeyError):
+            # Unexpected return shape - keep the flow working, just unpublished.
+            logger.warning(
+                "Could not read the authorization URL from the OAuth flow; "
+                "it will only be available in the logs."
+            )
+        return result
+
+    flow.authorization_url = capture_authorization_url
+
+
 def _is_file_empty(file_path: str) -> bool:
     """Check if a file exists and is empty.
 
@@ -369,9 +402,11 @@ def get_gmail_service():
                             else f"Stored OAuth state: {oauth_state}"
                         )
 
-                        # Set pending auth URL for web auth mode
-                        if is_web_auth_mode():
-                            state.pending_auth_url["url"] = authorization_url
+                        # Publish the URL so the web UI can show it. Useful in
+                        # every mode: in web auth mode no browser is opened at
+                        # all, and on a headless desktop the auto-open can
+                        # silently fail.
+                        state.pending_auth_url["url"] = authorization_url
 
                         # Create a simple HTTP server to handle the callback
                         callback_event = threading.Event()
@@ -500,6 +535,7 @@ def get_gmail_service():
                                     )
                     else:
                         # Use standard run_local_server when ports match
+                        _publish_authorization_url(flow)
                         new_creds = flow.run_local_server(
                             port=settings.oauth_port,
                             bind_addr=bind_address,

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -48,6 +48,16 @@ def _publish_authorization_url(flow) -> None:
     original_authorization_url = flow.authorization_url
 
     def capture_authorization_url(*args, **kwargs):
+        """Call through to the real ``authorization_url`` and publish its URL.
+
+        Args:
+            *args: Positional arguments forwarded unchanged.
+            **kwargs: Keyword arguments forwarded unchanged.
+
+        Returns:
+            Whatever the wrapped method returned, untouched - publishing is a
+            side effect and never changes the flow's own behaviour.
+        """
         result = original_authorization_url(*args, **kwargs)
         try:
             state.pending_auth_url["url"] = result[0]

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -1047,3 +1047,67 @@
     font-size: 12px;
     color: var(--text-tertiary);
 }
+
+/* ===== OAuth Authorization URL Panel ===== */
+
+.auth-url-panel {
+    margin: 24px auto 0;
+    padding: 20px;
+    max-width: 520px;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-sm);
+    text-align: center;
+}
+
+.auth-url-status {
+    margin: 0 0 16px;
+    font-size: 14px;
+    color: var(--text-secondary);
+}
+
+.auth-url-toggle {
+    display: block;
+    margin: 12px auto 0;
+    padding: 0;
+    background: none;
+    border: none;
+    font-size: 13px;
+    color: var(--primary-color);
+    text-decoration: underline;
+    cursor: pointer;
+}
+
+.auth-url-toggle:hover {
+    color: var(--primary-hover);
+}
+
+.auth-url-manual {
+    margin-top: 16px;
+    padding-top: 16px;
+    border-top: 1px solid var(--border-color);
+}
+
+.auth-url-manual p {
+    margin: 0 0 8px;
+    font-size: 13px;
+    color: var(--text-secondary);
+}
+
+.auth-url-copy-row {
+    display: flex;
+    gap: 8px;
+}
+
+.auth-url-copy-row input {
+    flex: 1;
+    min-width: 0;
+    padding: 8px 12px;
+    font-family: monospace;
+    font-size: 12px;
+    color: var(--text-primary);
+    background: var(--hover-bg);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+}

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -5,6 +5,9 @@
 window.GmailCleaner = window.GmailCleaner || {};
 
 GmailCleaner.Auth = {
+    // True once the consent URL has been rendered for the current sign-in.
+    authUrlShown: false,
+
     async checkStatus() {
         try {
             const response = await fetch('/api/auth-status');
@@ -70,20 +73,6 @@ GmailCleaner.Auth = {
                 return;
             }
 
-            if (status.web_auth_mode) {
-                const msg = `Docker detected! To sign in:
-
-1. Check Docker logs for the authorization URL:
-   docker logs cleanup_email-gmail-cleaner-1
-
-2. Copy the URL and open it in your browser
-
-3. After authorizing, you'll be signed in automatically.
-
-(Or generate token.json locally and mount it)`;
-                alert(msg);
-            }
-
             const signInResp = await fetch('/api/sign-in', { method: 'POST' });
             const signInResult = await signInResp.json();
 
@@ -100,25 +89,146 @@ GmailCleaner.Auth = {
         }
     },
 
+    // The OAuth flow runs on a background thread, so the consent URL only
+    // becomes available a moment after /api/sign-in returns.
     async pollStatus(attempts = 0) {
-        const maxAttempts = 120;
-        const signInBtn = document.getElementById('signInBtn');
+        // 300s, matching the timeout the custom-redirect-port flow uses.
+        const maxAttempts = 300;
 
         try {
             const response = await fetch('/api/auth-status');
             const status = await response.json();
 
             if (status.logged_in) {
+                this.hideAuthUrl();
                 this.updateUI(status);
-            } else if (attempts < maxAttempts) {
+                return;
+            }
+
+            if (!this.authUrlShown) {
+                await this.fetchAuthUrl();
+            }
+
+            if (attempts < maxAttempts) {
                 setTimeout(() => this.pollStatus(attempts + 1), 1000);
             } else {
-                this.resetSignInButton();
-                alert('Sign-in timed out. Please try again.');
+                // Only this page gives up. The sign-in may still be live on the
+                // server, so keep the link on screen and don't promise that
+                // starting over will work.
+                GmailCleaner.UI.showErrorToast(
+                    'Still waiting for Google authorization. Finish it in the Google tab, then reload this page.'
+                );
             }
         } catch (error) {
             console.error('Error polling auth status:', error);
             setTimeout(() => this.pollStatus(attempts + 1), 1000);
+        }
+    },
+
+    async fetchAuthUrl() {
+        try {
+            const response = await fetch('/api/web-auth-status');
+            const status = await response.json();
+            if (status && status.pending_auth_url) {
+                this.showAuthUrl(status.pending_auth_url);
+            }
+        } catch (error) {
+            // Transient failure - the next poll will retry.
+            console.error('Error fetching authorization URL:', error);
+        }
+    },
+
+    // Only ever put http(s) URLs into an href, even though this one comes from
+    // our own backend.
+    isSafeHttpUrl(url) {
+        if (typeof url !== 'string' || !url) return false;
+        try {
+            const protocol = new URL(url, window.location.origin).protocol;
+            return protocol === 'https:' || protocol === 'http:';
+        } catch (error) {
+            return false;
+        }
+    },
+
+    showAuthUrl(url) {
+        if (this.authUrlShown) return;
+
+        if (!this.isSafeHttpUrl(url)) {
+            console.error('Refusing to display non-http(s) authorization URL');
+            return;
+        }
+
+        const panel = document.getElementById('authUrlPanel');
+        const link = document.getElementById('authUrlOpen');
+        const input = document.getElementById('authUrlInput');
+        const statusEl = document.getElementById('authUrlStatus');
+        if (!panel || !link || !input) return;
+
+        this.authUrlShown = true;
+        link.href = url;
+        input.value = url;
+        panel.classList.remove('hidden');
+
+        // Best-effort auto-open. The URL arrives asynchronously, so this is
+        // outside the click's user-activation window and browsers will often
+        // block it - hence the button and copyable link above, which are the
+        // supported path rather than a fallback.
+        let opened = null;
+        try {
+            opened = window.open(url, '_blank', 'noopener');
+        } catch (error) {
+            opened = null;
+        }
+
+        if (statusEl) {
+            statusEl.textContent = opened
+                ? 'Opened Google sign-in in a new tab. Waiting for you to finish…'
+                : 'Authorize with Google to continue. Waiting for you to finish…';
+        }
+    },
+
+    hideAuthUrl() {
+        this.authUrlShown = false;
+
+        const panel = document.getElementById('authUrlPanel');
+        const link = document.getElementById('authUrlOpen');
+        const input = document.getElementById('authUrlInput');
+        const manual = document.getElementById('authUrlManual');
+
+        if (panel) panel.classList.add('hidden');
+        if (manual) manual.classList.add('hidden');
+        if (link) link.href = '#';
+        if (input) input.value = '';
+    },
+
+    toggleAuthUrl() {
+        const manual = document.getElementById('authUrlManual');
+        if (!manual) return;
+
+        manual.classList.toggle('hidden');
+        if (!manual.classList.contains('hidden')) {
+            const input = document.getElementById('authUrlInput');
+            if (input) input.select();
+        }
+    },
+
+    async copyAuthUrl() {
+        const input = document.getElementById('authUrlInput');
+        if (!input || !input.value) return;
+
+        try {
+            // navigator.clipboard needs a secure context, which a plain
+            // http://<host>:8766 deployment is not.
+            if (navigator.clipboard && window.isSecureContext) {
+                await navigator.clipboard.writeText(input.value);
+            } else {
+                input.select();
+                document.execCommand('copy');
+            }
+            GmailCleaner.UI.showSuccessToast('Authorization link copied');
+        } catch (error) {
+            input.select();
+            GmailCleaner.UI.showErrorToast('Could not copy automatically - press Ctrl+C');
         }
     },
 
@@ -143,6 +253,7 @@ GmailCleaner.Auth = {
 
         try {
             await fetch('/api/sign-out', { method: 'POST' });
+            this.hideAuthUrl();
             GmailCleaner.results = [];
             GmailCleaner.Scanner.updateResultsBadge();
             GmailCleaner.Scanner.displayResults();

--- a/templates/index.html
+++ b/templates/index.html
@@ -170,6 +170,24 @@
                                 </svg>
                                 Sign in with Google
                             </button>
+
+                            <!-- Shown once the OAuth flow has produced a consent URL -->
+                            <div class="auth-url-panel hidden" id="authUrlPanel">
+                                <p class="auth-url-status" id="authUrlStatus">Preparing Google sign-in&hellip;</p>
+                                <a class="btn btn-primary" id="authUrlOpen" href="#" target="_blank" rel="noopener noreferrer">
+                                    Continue to Google
+                                </a>
+                                <button class="auth-url-toggle" type="button" id="authUrlToggle" onclick="GmailCleaner.Auth.toggleAuthUrl()">
+                                    Signing in on another device?
+                                </button>
+                                <div class="auth-url-manual hidden" id="authUrlManual">
+                                    <p>Open this link on the device with your browser:</p>
+                                    <div class="auth-url-copy-row">
+                                        <input type="text" id="authUrlInput" readonly aria-label="Authorization URL">
+                                        <button class="btn btn-secondary" type="button" onclick="GmailCleaner.Auth.copyAuthUrl()">Copy</button>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
 

--- a/tests/unit/services/auth/test_pending_auth_url.py
+++ b/tests/unit/services/auth/test_pending_auth_url.py
@@ -1,0 +1,212 @@
+"""
+Tests for Publishing the OAuth Authorization URL
+------------------------------------------------
+The consent URL used to be printed to the container logs only, which forced
+Docker/Kubernetes users to run `docker logs` to sign in. These tests cover
+publishing it to `state.pending_auth_url` so the web UI can render it.
+"""
+
+import inspect
+from unittest.mock import Mock, patch, mock_open
+
+import pytest
+from google_auth_oauthlib.flow import InstalledAppFlow
+
+from app.core import state
+from app.services import auth
+
+
+AUTH_URL = "https://accounts.google.com/o/oauth2/auth?client_id=test&state=abc"
+
+
+class _InlineThread:
+    """Stand-in for threading.Thread that runs the target synchronously.
+
+    The OAuth flow runs on a background thread, which makes assertions racy.
+    Running it inline keeps these tests deterministic.
+    """
+
+    def __init__(self, target=None, daemon=None, **kwargs):
+        self._target = target
+
+    def start(self):
+        self._target()
+
+
+@pytest.fixture(autouse=True)
+def reset_pending_auth_url():
+    """Keep the global auth URL state from leaking between tests."""
+    state.pending_auth_url["url"] = None
+    yield
+    state.pending_auth_url["url"] = None
+
+
+def _configure_settings(mock_settings, external_port=None):
+    mock_settings.credentials_file = "credentials.json"
+    mock_settings.token_file = "token.json"
+    mock_settings.scopes = ["scope1"]
+    mock_settings.oauth_port = 8767
+    mock_settings.oauth_host = "localhost"
+    mock_settings.oauth_external_port = external_port
+
+
+def _only_credentials_exist(path):
+    if "token.json" in str(path):
+        return False
+    if "credentials.json" in str(path):
+        return True
+    return False
+
+
+class TestRunLocalServerPath:
+    """The default path (oauth_port == redirect port) uses run_local_server."""
+
+    @patch("app.services.auth.settings")
+    @patch("os.path.exists")
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data='{"installed": {"client_id": "test"}}',
+    )
+    @patch("app.services.auth.InstalledAppFlow")
+    @patch("app.services.auth.threading.Thread", _InlineThread)
+    @patch("app.services.auth._auth_in_progress", {"active": False})
+    @patch("app.services.auth.is_web_auth_mode", return_value=True)
+    def test_publishes_url_while_waiting_for_consent(
+        self, mock_web_auth, mock_flow, mock_file, mock_exists, mock_settings
+    ):
+        """The URL run_local_server builds internally must reach the UI state."""
+        _configure_settings(mock_settings)
+        mock_exists.side_effect = _only_credentials_exist
+
+        mock_flow_instance = Mock()
+        mock_flow.from_client_secrets_file.return_value = mock_flow_instance
+        mock_flow_instance.authorization_url.return_value = (AUTH_URL, "state-token")
+
+        seen = {}
+
+        def fake_run_local_server(**kwargs):
+            # Mirror what google-auth-oauthlib does internally.
+            mock_flow_instance.authorization_url(prompt="consent")
+            seen["url"] = state.pending_auth_url["url"]
+            return Mock()
+
+        mock_flow_instance.run_local_server.side_effect = fake_run_local_server
+
+        auth.get_gmail_service()
+
+        # Published while the user is being asked to consent...
+        assert seen.get("url") == AUTH_URL
+        # ...and cleared once the flow finishes.
+        assert state.pending_auth_url["url"] is None
+
+
+class TestCustomRedirectPortPath:
+    """The manual path (custom external port) publishes in every auth mode."""
+
+    @patch("app.services.auth.settings")
+    @patch("os.path.exists")
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data='{"installed": {"client_id": "test"}}',
+    )
+    @patch("app.services.auth.HTTPServer")
+    @patch("app.services.auth.InstalledAppFlow")
+    @patch("app.services.auth.threading.Thread", _InlineThread)
+    @patch("app.services.auth._auth_in_progress", {"active": False})
+    @patch("app.services.auth.is_web_auth_mode", return_value=False)
+    def test_publishes_url_outside_web_auth_mode(
+        self,
+        mock_web_auth,
+        mock_flow,
+        mock_http_server,
+        mock_file,
+        mock_exists,
+        mock_settings,
+    ):
+        """Desktop users whose browser fails to open still need the URL."""
+        _configure_settings(mock_settings, external_port=18767)
+        mock_exists.side_effect = _only_credentials_exist
+
+        mock_flow_instance = Mock()
+        mock_flow.from_client_secrets_file.return_value = mock_flow_instance
+        mock_flow_instance.authorization_url.return_value = (AUTH_URL, "state-token")
+
+        seen = {}
+
+        def stop_after_publish(*args, **kwargs):
+            # The URL is published before the callback server starts; capture it
+            # there and abort rather than blocking on a real callback.
+            seen["url"] = state.pending_auth_url["url"]
+            raise OSError("stop the flow here")
+
+        mock_http_server.side_effect = stop_after_publish
+
+        auth.get_gmail_service()
+
+        assert seen.get("url") == AUTH_URL
+
+
+class TestPublishAuthorizationUrlHelper:
+    """Direct tests for the wrapper installed around Flow.authorization_url."""
+
+    def test_wrapper_matches_the_real_library_contract(self):
+        """Run against a genuine Flow so a changed return shape is caught."""
+        client_config = {
+            "installed": {
+                "client_id": "fake-id.apps.googleusercontent.com",
+                "client_secret": "fake-secret",  # nosec B105 - not a real secret
+                "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                "token_uri": "https://oauth2.googleapis.com/token",
+            }
+        }
+        flow = InstalledAppFlow.from_client_config(
+            client_config, scopes=["https://www.googleapis.com/auth/gmail.readonly"]
+        )
+        flow.redirect_uri = "http://localhost:8767/"
+
+        auth._publish_authorization_url(flow)
+        url, _ = flow.authorization_url(prompt="consent")
+
+        assert url.startswith("https://accounts.google.com/o/oauth2/auth")
+        assert state.pending_auth_url["url"] == url
+
+    def test_run_local_server_still_builds_its_url_via_authorization_url(self):
+        """Guard the dependency internal this feature hooks into.
+
+        `_publish_authorization_url` works by wrapping `Flow.authorization_url`,
+        which `run_local_server` calls to build the consent URL. If an upgrade
+        of google-auth-oauthlib changes that, the URL silently stops reaching
+        the UI - so fail loudly here instead.
+        """
+        source = inspect.getsource(InstalledAppFlow.run_local_server)
+        assert "self.authorization_url(" in source
+
+    def test_unexpected_return_shape_does_not_break_the_flow(self):
+        """A changed return type must not take the whole sign-in down."""
+        flow = Mock()
+        flow.authorization_url.return_value = None
+
+        auth._publish_authorization_url(flow)
+        result = flow.authorization_url()
+
+        assert result is None
+        assert state.pending_auth_url["url"] is None
+
+
+class TestWebAuthStatusExposesUrl:
+    """The status endpoint is how the browser learns about the URL."""
+
+    @patch("app.services.auth.settings")
+    @patch("app.services.auth.needs_auth_setup", return_value=True)
+    @patch("app.services.auth.os.path.exists", return_value=True)
+    def test_status_reports_the_pending_url(
+        self, mock_exists, mock_needs_setup, mock_settings
+    ):
+        _configure_settings(mock_settings)
+        state.pending_auth_url["url"] = AUTH_URL
+
+        status = auth.get_web_auth_status()
+
+        assert status["pending_auth_url"] == AUTH_URL

--- a/tests/unit/services/auth/test_pending_auth_url.py
+++ b/tests/unit/services/auth/test_pending_auth_url.py
@@ -27,9 +27,11 @@ class _InlineThread:
     """
 
     def __init__(self, target=None, daemon=None, **kwargs):
+        """Record the target callable, ignoring the threading-specific kwargs."""
         self._target = target
 
     def start(self):
+        """Run the target immediately on the calling thread."""
         self._target()
 
 
@@ -42,6 +44,14 @@ def reset_pending_auth_url():
 
 
 def _configure_settings(mock_settings, external_port=None):
+    """Populate a mocked ``settings`` with the attributes the auth flow reads.
+
+    Args:
+        mock_settings: The patched ``app.services.auth.settings`` mock.
+        external_port: Value for ``oauth_external_port``. Leave ``None`` to take
+            the ``run_local_server`` path; set it to force the manual
+            custom-redirect-port path.
+    """
     mock_settings.credentials_file = "credentials.json"
     mock_settings.token_file = "token.json"
     mock_settings.scopes = ["scope1"]
@@ -51,6 +61,11 @@ def _configure_settings(mock_settings, external_port=None):
 
 
 def _only_credentials_exist(path):
+    """Fake ``os.path.exists`` for a first-run state.
+
+    Reports ``credentials.json`` as present and ``token.json`` as missing, which
+    is what drives ``get_gmail_service`` into a fresh authorization flow.
+    """
     if "token.json" in str(path):
         return False
     if "credentials.json" in str(path):
@@ -86,6 +101,11 @@ class TestRunLocalServerPath:
         seen = {}
 
         def fake_run_local_server(**kwargs):
+            """Stand in for ``run_local_server``, capturing the published URL.
+
+            Calls ``authorization_url`` the way the real library does, then
+            records what the UI would have seen at that moment.
+            """
             # Mirror what google-auth-oauthlib does internally.
             mock_flow_instance.authorization_url(prompt="consent")
             seen["url"] = state.pending_auth_url["url"]
@@ -136,6 +156,12 @@ class TestCustomRedirectPortPath:
         seen = {}
 
         def stop_after_publish(*args, **kwargs):
+            """Capture the published URL, then abort the flow.
+
+            Raises:
+                OSError: Always, to unwind the flow instead of blocking on a
+                    real OAuth callback.
+            """
             # The URL is published before the callback server starts; capture it
             # there and abort rather than blocking on a real callback.
             seen["url"] = state.pending_auth_url["url"]
@@ -204,6 +230,7 @@ class TestWebAuthStatusExposesUrl:
     def test_status_reports_the_pending_url(
         self, mock_exists, mock_needs_setup, mock_settings
     ):
+        """/api/web-auth-status must surface whatever URL is currently pending."""
         _configure_settings(mock_settings)
         state.pending_auth_url["url"] = AUTH_URL
 


### PR DESCRIPTION
## The problem

Clicking **Sign in with Google** returns `{"status":"signing_in"}` and prints the Google consent URL to the container log — and nowhere else. On Docker or Kubernetes the user has to leave the browser, run `docker logs` / `kubectl logs`, find the URL and paste it back. The log is the only path to signing in. (Related to the confusion in #109.)

The README currently documents this as the intended flow, which is the clearest sign it needs fixing.

## What this does

The URL is surfaced in the page itself:

- A **Continue to Google** button appears as soon as the URL is available.
- The app *also* attempts to open it in a new tab, but see the honesty note below — that is a bonus, not the mechanism.
- **Signing in on another device?** reveals the raw URL with a copy button, for anyone whose browser is not on the machine running the container.


## The part that surprised me

`state.pending_auth_url` already existed and `/api/web-auth-status` already returned it — but **nothing populated it in the default configuration**, so a frontend-only change would have polled forever for a field that stays `null`.

It was only ever set in the custom-external-port branch. The shipped `docker-compose.yml` (`WEB_AUTH=true`, no `OAUTH_EXTERNAL_PORT`) takes the `run_local_server()` branch, which never touched it. So the users most affected by the log-only workflow were exactly the ones for whom the field was dead.

`run_local_server()` builds the consent URL internally via the public `Flow.authorization_url`:

```python
auth_url, _ = self.authorization_url(**kwargs)
```

so that method is wrapped to record the URL rather than reimplementing the flow. If a future version of `google-auth-oauthlib` stops routing through it, the URL simply stays `None` and behaviour falls back to today's log-only output — nothing breaks. There is a guard test that greps the library's source so that a dependency bump fails loudly instead of silently; if you find that too clever it can be dropped, the graceful degradation stands on its own.

The custom-redirect-port path also no longer gates publishing on web-auth mode, so desktop users whose browser fails to auto-open can see the URL too.

The URL is still printed to the logs.

## Please decide this consciously

**The authorization URL is now readable over unauthenticated HTTP, where it was previously log-only.**

I do not think it grants anything new — the app has no authentication, so anyone who can reach it can already click Sign In and drive the same flow — but it is a real change in exposure and reviewers should agree to it rather than discover it. The URL contains the `client_id` (not a secret), a CSRF `state`, and a PKCE challenge. ~~If you would rather gate it behind `WEB_AUTH=true`, that is a one-line change.~~ **Correction:** that suggestion is wrong — see [this comment](https://github.com/Gururagavendra/gmail-cleaner/pull/117#issuecomment-5440846495). Gating on `WEB_AUTH` is inverted: web-auth mode binds the callback to `0.0.0.0` (the exploitable case) while desktop mode binds `localhost` (the safe one), so it would publish the URL exactly where it matters and withhold it where it doesn't. Please disregard.

## Honesty about the auto-open

**Auto-open will often be blocked, and I expect that.** The URL is produced by a background thread and arrives ~1s *after* the click, so `window.open` fires outside the click's user-activation window and browsers treat it as a popup. In my headless-Chrome verification it *was* blocked, and the status text correctly fell back to "Authorize with Google to continue."

The button and the copyable URL are the supported path. Auto-open is opportunistic. I chose not to redirect the top-level window instead, because that would throw away the polling page that completes the sign-in.

Similarly, `navigator.clipboard` needs a secure context, which a plain `http://<host>:8766` deployment is not — so copy falls back to `execCommand`.

## Timeout wording

The poll ceiling moves 120s → 300s, matching the timeout the custom-redirect-port flow already uses. When the page stops polling it keeps the link on screen and says the sign-in may still be live on the server, rather than claiming a timeout and inviting a retry — on this branch the `run_local_server` path has no server-side deadline of its own. #116 fixes that separately; this wording is accurate either way, before or after #116 lands.

## Verified

- 140 tests pass (134 on `main` + 6 new). **I checked the new tests fail without the fix** — 4 of the 6 do; the other two are the dependency-contract guard and existing status plumbing, which legitimately pass either way.
- `ruff check`, `ruff format --check`, `bandit -ll -i -r app/` (0 medium/high) clean.
- Built the image and ran it with a throwaway `credentials.json` in two configurations — stock compose, and `OAUTH_EXTERNAL_PORT` set. In both, `/api/web-auth-status` served the real consent URL ~1s after `POST /api/sign-in`, where before it stayed `null`.
- Drove the actual UI in headless Chrome: panel hidden before the click, visible after; `href` is a genuine `accounts.google.com/o/oauth2/auth` URL carrying `state`; the toggle reveals the input; the input matches the `href` exactly; no alert dialog appears.
- No dependency, `uv.lock` or `Dockerfile` changes.

## Not verified

- **Real Google consent cannot be automated.** I verified up to the point where the URL is rendered and clickable. I did not complete an actual authorization against Google with these changes, so the post-consent callback path is unchanged-by-inspection rather than re-tested.
- Auto-open *succeeding* is unverified — it was blocked in headless, which is the expected case.
- No JS test infrastructure exists in the repo, so the frontend is covered by the browser check above rather than unit tests.

## Related

#116 splits out an independent bug in the same file (an abandoned sign-in latches `_auth_in_progress` forever). They touch different parts of `app/services/auth.py` and can land in either order; whichever lands second may need a trivial context merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added a web UI flow for Google OAuth authorization.
- Added a **Continue to Google** button with automatic new-tab opening.
- Added an expandable raw URL with copy support for alternate-device sign-in.
- Published authorization URLs through `pending_auth_url` for local-server and custom-redirect flows.
- Preserved authorization URLs in logs and after polling stops.
- Extended authorization polling from 120 to 300 seconds.
- Added a clipboard fallback for non-secure HTTP deployments.
- Added unit tests for authorization URL publishing and the web-auth status endpoint.
- Updated Docker OAuth setup documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
